### PR TITLE
Fix variable shadowing in page.html scripts block

### DIFF
--- a/layouts/page.html
+++ b/layouts/page.html
@@ -15,7 +15,7 @@
 {{ define "scripts" }}
 {{- $toc := .TableOfContents -}}
 {{ if and $toc (ne .Params.toc false) (gt (len (findRE "<li>" $toc)) 0) }}
-{{ $toc := resources.Get "js/toc.js" | fingerprint "md5" }}
-<script src="{{ $toc.RelPermalink }}"></script>
+{{ $tocScript := resources.Get "js/toc.js" | fingerprint "md5" }}
+<script src="{{ $tocScript.RelPermalink }}"></script>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Rename $toc to $tocScript for the JS resource to avoid shadowing the TableOfContents variable, improving code clarity