### PR TITLE
MOZa Weekly 22 april 2026

### DIFF
--- a/.claude/skills/new-weekly/SKILL.md
+++ b/.claude/skills/new-weekly/SKILL.md
@@ -32,9 +32,13 @@ Secties sluiten vaak aan op bestaande onderwerpen (zie `content/onderwerpen/`) o
 
 Agenda is **cumulatief**: neem items uit de vorige weekly over die nog niet zijn geweest, verwijder voorbije items (inclusief de publicatiedatum zelf — de weekly verschijnt 's ochtends). Structuur en inleidingsregel uit de vorige weekly overnemen. Items staan in **chronologische volgorde**.
 
+**Vaste overleggen altijd op de agenda**: MOZa Pulse, Regieteam en Stuurgroep horen altijd met een eerstvolgende datum op de agenda. Als één van deze drie is geweest en er geen nieuwe datum in de input staat, vraag proactief om de volgende datum voordat je de weekly afrondt.
+
 ## Bij onduidelijkheden
 
 Benoem expliciet aan de gebruiker wat ontbreekt (datums, links, context) in plaats van te gokken.
+
+**Voorbije events zonder update**: loop de agenda van de vorige weekly langs en kijk welke items tussen toen en nu zijn geweest. Als een voorbij event niet in de input wordt genoemd, vraag proactief of er toch iets over te melden is — soms is dat namelijk wel zo.
 
 ## Publiceren
 

--- a/content/weekly/2026/2026-04-08.md
+++ b/content/weekly/2026/2026-04-08.md
@@ -52,7 +52,7 @@ date: 2026-04-08
 
 * [Common Ground Fieldlab](https://commonground.nl/events/view/df0a6e7b-2b9c-4fef-93e2-9b6d88ee34b3/common-ground-fieldlab-11-en-12-mei-2026) - 11 & 12 mei (MOZa organiseert een sessie)
 * Werkgroep NL Design Systems - 12 mei
-* OneTeamGov - 12 mei
+* OneTeamGov - 21 mei
 * Wallets sessie - 6 mei
 * VNG MijnServices Festival - 28 mei
 * Demo usecase verificatie QTSP – project UBO/BronConnect - 28 mei

--- a/content/weekly/2026/2026-04-15.md
+++ b/content/weekly/2026/2026-04-15.md
@@ -52,7 +52,7 @@ date: 2026-04-15
 * Wallets sessie - 6 mei
 * [Common Ground Fieldlab](https://commonground.nl/events/view/df0a6e7b-2b9c-4fef-93e2-9b6d88ee34b3/common-ground-fieldlab-11-en-12-mei-2026) - 11 & 12 mei (MOZa organiseert een sessie)
 * Werkgroep NL Design Systems - 12 mei
-* OneTeamGov - 12 mei
+* OneTeamGov - 21 mei
 * VNG MijnServices Festival - 28 mei (MOZa staat op de vloer)
 * Demo usecase verificatie QTSP – project UBO/BronConnect - 28 mei
 * [Symposium European Business Wallet](https://ecp.nl/agenda/symposium-de-european-business-wallet-het-fundament-voor-een-concurrerend-digitaal-bedrijfsleven/) (ECP, Jaarbeurs) - 2 juni

--- a/content/weekly/2026/2026-04-22.md
+++ b/content/weekly/2026/2026-04-22.md
@@ -1,0 +1,71 @@
+---
+title: MOZa Weekly 22 april 2026
+date: 2026-04-22
+---
+
+## Algemeen
+
+* **Dag van de toekomst: ondernemer centraal:** op 18 juni organiseren we deze dag samen met [Digilab](https://digilab.overheid.nl/). Deze week is het plan om de uitnodigingen te versturen. Naast de introducties van onderwerpen inclusief demo kan er gekozen worden uit twee tracks: (1) Rollen en bevoegdheden in het ondernemersdomein, en (2) Regeldruk, beleid en techniek. Heb je ideeën voor een inspirerende openingsspreker voor dit onderwerp dan ontvangen wij graag suggesties.
+* **[VNG MijnServices Festival](https://www.digitaleoverheid.nl/evenementen/mijnservices-festival/):** op 28 mei staan we op de vloer bij het MijnServices Festival. We zijn bezig met de voorbereidingen. O.a. hebben we de onderwerpen voor onze presentatie en demo op een rij gezet. We stemmen dit ook af met MijnOverheid en Obis.
+* **Tactisch afnemersoverleg (TAO) MijnOverheid:** we hebben op basis van de eerder opgestelde concept roadmap van MOZa epics toegevoegd aan de roadmap MijnOverheid. De onderwerpen die spelen binnen MOZa zijn daarbij gekoppeld aan thema's van MijnOverheid. Zo brengen we de verschillende plannen dichter bij elkaar en wordt prioriteren in overleg met Logius eenvoudiger.
+* **Kaders Logius:** een eerste concept versie is gemaakt door Logius. Het MOZa team kijkt hier nu naar en iteratief werken we toe naar een eerste versie.
+* **MOZa Pulse:** de Pulse met demo's van Federatieve Berichten en Digitale Assistent verliep soepel. Het was ook een mooie samenwerking voor ons als team. Zo komen de verschillende demo's nu samen in één interface. Deze kun je bekijken op [proef.moza.rijksapp.dev](https://proef.moza.rijksapp.dev/).
+* **Gebruikersonderzoek:** de rapportage van het gebruikersonderzoek uit maart staat nu [in de samenwerkruimte](https://www.samenwerkruimten.nl/teamsites/programma%20mijnoverheid%20voor%20ondernemers/Gedeelde%20%20documenten/Forms/AllItems.aspx?id=%2Fteamsites%2Fprogramma%20mijnoverheid%20voor%20ondernemers%2FGedeelde%20%20documenten%2F03%20%2D%20Programma%20inhoudelijke%20documenten%2F01%20%2D%20Gebruikersonderzoeken%20en%20input%2F01%20%2D%20Onderzoeken%2F01%20%2D%20mrt%202026).
+* **MOx-NLDS:** de structuur is vereenvoudigd van atoms/molecules/organisms naar atoms en components. Er staat [een storybook](https://minbzk.github.io/moza-mox-nlds/) met een versie met tokens die ook in Figma werkt. Daarnaast hebben we een uitgebreide refactor op de tokens gedaan.
+* **Rijkshuisstijl Community (RHC):** met KOOP verkennen we of we op kortere termijn toch RHC-componenten kunnen afnemen en eraan kunnen bijdragen. Het ritme van oplevering helpt ons nu nog niet, maar we willen zorgen dat aansluiten later soepel verloopt.
+
+## MOZa team
+
+* **Niet één, maar twee:** vanaf nu werken we in twee teams, waarbij we met elkaar de verbinding blijven opzoeken. Hiervoor hebben we afspraken met elkaar gemaakt en de gezamenlijke rituelen zijn afgestemd. Het ene team heeft voor nu de focus op Notificeren, Profiel en MijnOmgeving. Het andere team op Berichten en Digitale Assistent. Sprekende teamnamen zijn nog een open puntje, dus voorlopig is het nog Team A en Team B.
+* **Nieuwe collega's aan boord:** er zijn twee nieuwe collega's gestart voor communicatie en software engineering. Zij worden nu ingewerkt, waarbij we handig gebruik maken van "[jouw start](/handboek/jouw-start/)" sectie in ons handboek.
+* **Versterking gezocht:** we zoeken nog extra collega's voor vervanging op domeinarchitectuur, ondersteuning bij beleid (medior/senior) en uitbreiding met een business analist. Ken je iemand? Dan komen we graag in contact.
+
+## MOZa Services
+
+* **Berichtenbox in prototype:** een semi-werkende [Berichtenbox](https://proef.moza.rijksapp.dev/moza/berichtenbox/) is samengevoegd in de prototype-omgeving. Het is een eerste verkenning hoe dit qua gebruikerservaring kan werken. We weten dat er al veel gebruikersonderzoek is gedaan en gaan dit in een toekomstige iteratie ook bekijken.
+* **Belastingdienst - tweede verdieping:** we hebben een tweede verdieping gedaan over notificeren, contactherstel en profiel. Er is een denkrichting richting een oplossing, die ook weer nieuwe vragen oproept, ook juridisch. Bij de derde verdieping op 20 mei sluiten daarom juristen aan.
+* **Scope profielservice en notificatieservice:** met Obis en BZK bespraken we de scope voor burgers en ondernemers. Er begint een lijn te ontstaan in hoe we dit willen en kunnen doen. Tegelijk zijn er ook de nodige vragen over gesteld, waarbij er vanuit beleid nog extra naar gekeken wordt. Er komt een vervolgoverleg in de loop van mei om met elkaar knopen door te hakken.
+* **[Actualiteitenservice](https://github.com/MinBZK/moza-actualiteiten-service) als losse service:** we trekken de actualiteitenservice los als zelfstandige service. In [een ADR](https://github.com/MinBZK/MijnOverheidZakelijk/pull/437) onderbouwen we waar de voorkeursinformatie voor actualiteiten thuishoort: postcode-, onderwerp- en favorietenvoorkeuren horen bij de actualiteitenservice zelf, niet in de profielservice. Nevenservices identificeren de partij via de subject-claim uit het JWT.
+* **[Profielservice](/onderwerpen/profielservice/):** we ondersteunen nu aanhef- en taalvoorkeuren in de profielservice en het portaal, en hebben het datamodel hierop aangescherpt. Daarnaast hebben we de randvoorwaarden voor bètastatus en live-gang in kaart gebracht. Dit is nog niet getoetst aan de kaders waar we nu ook met Logius samen aan werken.
+* **Logboek Dataverwerkingen:** de toelichting op [LDV](https://logius-standaarden.github.io/logboek-dataverwerkingen/) in [de technische documentatie](https://docs.mijnoverheidzakelijk.nl) is uitgebreid.
+* **Gemeente Amsterdam:** Amsterdam wil graag direct gebruikmaken van een centrale profielservice. 'Extern' gebruik is in de eerste iteratie nog niet voorzien, dus we zoeken samen naar een werkwijze die binnen de huidige kaders past.
+* **CBS:** CBS communiceert nu alles via post. We verkennen hoe we samen kunnen optrekken om het digitale kanaal via de centrale opzet te implementeren.
+* **Gegevensdeling in nieuwe wetgeving bij LVVN:** we haakten aan bij een update over dit onderwerp. LVVN verkent hoe gegevensdeling kan worden meegenomen in nieuwe wetgeving, waarbij [RegelRecht](https://regelrecht.rijks.app/) een rol speelt. Richting de toekomst zien we mogelijkheden om dit in de MOZa-proeftuin te beproeven, zodat we zien hoe het voor eindgebruikers werkt.
+
+## Digitale Assistent
+
+* **Demo's:** de Digitale Assistent is gedemonstreerd op de ODI Impactdag en de MOZa Pulse. Er staat een vervolgdemo gepland bij de Douane, met een iets technischer team.
+* **Digitale Assistent in prototype:** de [Digitale Assistent](https://proef.moza.rijksapp.dev/moza/digitale-assistent/) is samengevoegd met het prototype, zodat we alles in één omgeving kunnen tonen. We kijken nog hoe we hier veilig ook een werkend taalmodel aan kunnen koppelen, zodat het echt uitgeprobeerd kan worden.
+* **MKBot en DAO:** we spraken met het technische team achter de MKBot en met product owner + ontwikkelaars van het DAO-team. MKBot zet een zelfgebouwde datalaag in voor een RAG-bot; dat past minder bij onze federatieve aanpak. DAO focust op search/retrieval binnen RAG, wij op acties. In de toekomst kunnen we mogelijk op elkaars werk voortbouwen. We onderzoeken verdere samenwerking.
+* **[RegelRecht](https://regelrecht.rijks.app/) en rapportageverplichtingen:** van EZ ontvingen we scenario's voor bottlenecks bij rapportageverplichtingen. We kijken hoe we hier een technisch voorstel voor kunnen maken waarin MOZa en RegelRecht samen een rol spelen.
+
+## Agenda
+
+💡 Wist je dat we (bijna) elke maandag samenwerken op het Beatrixpark in Den Haag? Wil je een keer aanhaken, dan ben je van harte welkom.
+
+**MOZa**
+
+* RVO - eerste verdieping notificeren - 22 april
+* Gebruikersonderzoek met ondernemers - 24 april en 29 april
+* EU Business Wallets kennis delen - 6 mei
+* Deadline PGDI-budgetaanvraag - 6 mei
+* Regieteam - 7 mei
+* Vervolg scope profielservice en notificatieservice - 19 mei
+* Belastingdienst - derde verdieping notificeren - 20 mei
+* MOZa Pulse - 21 mei
+* Stuurgroep - 22 mei
+* Dag van de toekomst: ondernemer centraal (met Digilab) - 18 juni
+
+**Evenementen**
+
+* [Common Ground Fieldlab](https://commonground.nl/events/view/df0a6e7b-2b9c-4fef-93e2-9b6d88ee34b3/common-ground-fieldlab-11-en-12-mei-2026) - 11 & 12 mei (MOZa organiseert een sessie samen met Gemeente Amsterdam)
+* Werkgroep NL Design Systems - 12 mei
+* OneTeamGov - 21 mei
+* VNG MijnServices Festival - 28 mei (MOZa staat op de vloer en verzorgt presentaties / demo's)
+* Demo usecase verificatie QTSP - project UBO/BronConnect - 28 mei
+* [Symposium European Business Wallet](https://ecp.nl/agenda/symposium-de-european-business-wallet-het-fundament-voor-een-concurrerend-digitaal-bedrijfsleven/) (ECP, Jaarbeurs) - 2 juni
+* [OneGov AI Hackathon Series](https://www.digitaleoverheid.nl/evenementen/onegov-ai-hackathon-series/) (The Hague Tech) - 4 & 5 juni
+* [GovTech Day](https://www.digitaleoverheid.nl/evenementen/govtech-day/) - 11 juni
+* [Overheid360°](https://www.digitaleoverheid.nl/evenementen/overheid360/) (Jaarbeurs Utrecht) - 17 juni
+* [Samen versnellen met AI: de overheid van morgen begint nu](https://www.aanmelder.nl/174738) - 25 juni
+* [Dag van de Digitale Toegankelijkheid](https://dagvandedigitaletoegankelijkheid.nl/) - 28 juni


### PR DESCRIPTION
## Summary
- Nieuwe MOZa Weekly voor 22 april 2026 toegevoegd
- OneTeamGov-datum gecorrigeerd (12 → 21 mei) in weeklies van 8 en 15 april
- new-weekly skill verfijnd: vaste overleggen (Pulse, Regieteam, Stuurgroep) altijd op agenda, en proactief navragen bij voorbije events zonder update

## Test plan
- [ ] Weekly rendert correct op `/weekly/2026/2026-04-22/`
- [ ] Agenda-items staan in chronologische volgorde
- [ ] Interne links (profielservice, handboek/jouw-start) werken
- [ ] Externe links (samenwerkruimte, ADR, LDV, evenementen) werken