### PR TITLE
Opzet mox-nlds onderwerp-pagina

### DIFF
--- a/content/onderwerpen/mox-nlds.md
+++ b/content/onderwerpen/mox-nlds.md
@@ -1,0 +1,86 @@
+---
+title: "MOX-nlds"
+description: "Ons design systeem voor consistente & stabiele React componenten"
+---
+
+## Wat is MOX-nlds?
+
+MOX-nlds is een design systeem voor de ontwikkeling van de [MijnOverheid Zakelijk portaal](portaal). In potentie kan het systeem ook ingezet worden voor andere interfaces binnen het MijnOverheid Zakelijk ecosysteem (zoals b.v. deze website).
+Een design systeem is een verzameling van herbruikbare componenten, richtlijnen en standaarden die consistentie en efficiëntie bevorderen in het ontwerp en de ontwikkeling van digitale producten. Omdat we de vormgeving baseren op de richtlijnen van de Rijkshuisstijl, is MOX-nlds naast MOZa producten ook (uiteindelijk) te gebruiken voor andere webapplicaties/websites, zoals b.v. [Mijn Overheid](https://mijnoverheid.nl), [PRO websites](https://www.platformrijksoverheidonline.nl/). In principe alles dat moet voldoen aan de Rijkshuisstijl.
+
+## Rijkshuisstijl Community Design Systeem / NLDS
+
+Momenteel is het [Rijkshuisstijl Community Design Systeem](https://www.rijkshuisstijl-community.nl/) (RHC-nlds) in ontwikkeling. Dit is een initiatief dat het bovenstaande doel ook heeft, en de _NLDS_ aanpak daarin hanteert als leidraad. De belangrijkste uitgangspunten daarin zijn:
+
+- **Design tokens gebruik**: via een `JSON` bestand worden allerlei styling eigenschappen (kleuren, fonts, groottes, line-heights, etc) vastgelegd. Deze `JSON` dient als de _single source of truth_ en kan vertaald worden naar Figma (voor designers) of CSS (voor developers). Een gebruiker kan deze tokens naar gelieven aanpassen voor een 'eigen sausje' over de Rijkshuisstijl.
+- **Herbruikbare componenten**: b.v. een breadcrumb hoeft maar één keer ontworpen en ontwikkeld te worden, waarna andere sites / partijen deze kunnen importeren en gebruiken.
+- **Estafettemodel**: een concept waarin meerdere partijen samenwerken om componenten te verbeteren om ze tot een _production-ready_ te krijgen (zie: [estafettemodel](https://www.nldesignsystem.nl/handboek/estafettemodel/)). Een partij die iets mist kan dat bouwen en toevoegen aan het Rijkshuisstijl Community Design System, waarna anderen het kunnen doorontwikkelen.
+
+## Waarom kunnen we het Rijkshuisstijl Community Design Systeem niet gebruiken?
+
+Momenteel is het RHC-nlds nog in ontwikkeling. De manier waarop RHC-nlds opgezet is zorgt echter voor een aantal problemen waardoor MijnOverheid Zakelijk er niet goed mee kan werken:
+
+- De componenten zijn zeer inconsistent in styling, kwaliteit, naamgeving en gebruik. Dit komt door het estafettemodel waar componenten uit diverse hoeken komen, maar een centrale controle-check ontbreekt.
+- De design-tokens (`JSON`) zijn opgezet voor _elk_ component, wat een wildgroei heeft opgeleverd. De hoeveelheid is zo groot dat we er niet goed meer mee overweg kunnen.
+- Tegelijkertijd missen de componenten vaak weer nét de dingen die je zou willen aanpassen.
+- Aanpassen van componenten is lastig: een simpel tekst-blok in een `<Badge>` kan compleet anders werken dan een tekst-blok in een `<Button>` en vaak moet je custom zelf iets bouwen. Design-tokens gebruiken voor consistente vormgeving is daarbij link: deze veranderen vaak, waardoor je styling zal breken zonder dat je dat weet.
+- Er is geen goed fluid (responsive) type/spacing-systeem opgezet in de basis
+
+## Wat maakt een overheidsbreed design systeem goed bruikbaar?
+
+Wat je uit het Design Systeem voor alle overheids-partijen wilt is:
+
+- Kant en klare componenten die gewoon goed werken (i.e. responsive zijn, kunnen werken met dark-mode, zeer voorspelbaar zijn in styling en gebruik)
+- De mogelijkheid om deze componenten open te maken en aan te passen, zonder dat je hoeft te _opt-out_'en. Je wilt nog steeds gebruik maken van de onderliggende regels voor spacing, kleuren, etc.
+
+## Aanpak MOX-nlds
+
+We pakken de goede ideëen uit RHC-nlds op, en bouwen onze eigen stabiele basis voor een Design Systeem.
+
+> Wat MOX-nlds is: gebruiksgemak, voorspelbaarheid en flexibiliteit
+
+### Atomic design system
+
+We zetten ons design systeem _atomisch_ op. Dat betekent dat we enkele bouwlagen hebben:
+
+- **Atoms**: de kleinste bouwblokken (zoals een tekst, een box, een radio-button). Deze leunen op de design tokens.
+- **Components** (aka **Molecules** en **Organisms**): opgebouwd uit **Atoms** (zoals een radio-button met label, correcte spacing en foutmelding-optie) Components maken expliciet geen gebruik meer van de design tokens.
+- **Templates**: opgebouwd uit **Atoms** en **Molecules**. Grote kant-en-klare blokken zoals bijvoorbeeld een compleet contact-formulier.
+
+```mermaid
+---
+title: Opzet MOX-nlds als atomic design system
+---
+flowchart LR
+    accTitle: MOX-nlds atomic design system
+    accDescr: De verschillende stappen waaruit het atomic design system is opgebouwd
+    A[Design tokens] --> B[Atoms]
+    B --> C[Components]
+    C --> D[Templates]
+```
+
+Als je een kant en klaar component nodig hebt zonder enige aanpassingen, dan is een **component** of zelfs een **template** geschikt. Heb je meer _fine-grained control_ nodig wat het component niet biedt, dan kijk je in Storybook hoe het component opgezet is. Je kan met de **atoms** vervolgens je eigen component opzetten met aanpassingen waar nodig.
+
+Atoms zijn zeer voorspelbaar opgezet. Hun gedrag en mogelijkheden tot aanpassen zijn altijd hetzelfde, wat zorgt dat je als developer snel je eigen componenten kan opzetten.
+
+Zie voor meer informatie de Storybook: [Atomisch systeem](https://minbzk.github.io/moza-mox-nlds/?path=/docs/atomic-system--docs).
+
+### Fluid type/spacing systeem
+
+Zodra tekst op een kleiner scherm kleiner wordt, moet bijvoorbeeld de afstand tussen een radio-button en zijn label ook meeschalen. Dit moet je in de basis goed opzetten.
+
+Zie voor meer informatie de Storybook: [Scaling systeem](https://minbzk.github.io/moza-mox-nlds/?path=/docs/scaling-system--docs)
+
+## Werkwijze & status
+
+Momenteel verkeert het MOX-nlds nog in een alpha-versie.
+
+Er wordt via het [prototype](https://www.mijnoverheidzakelijk.nl/onderwerpen/ontwerpprincipes/) gewerkt aan componenten die getest worden in UX-onderzoeken. Zodra een component qua design goed bevonden is, kan het verwerkt worden tot een component in MOX-nlds. Momenteel zijn er al een aantal componenten klaar.
+
+Momenteel ligt de focus op het bouwen van een goede basis voor de **atoms**, waarna we snel **componenten** kunnen bijbouwen. Deze worden dan toegepast in de MijnOverheid Zakelijk portaal.
+
+## Relevante links
+
+- [De Storybook voor MOX-nlds](https://minbzk.github.io/moza-mox-nlds/?path=/docs/intro--docs).
+- [Rijkshuisstijl Community Design System](https://www.rijkshuisstijl-community.nl/)
+- [NL Design System](https://www.nldesignsystem.nl)

--- a/content/onderwerpen/portaal/_index.md
+++ b/content/onderwerpen/portaal/_index.md
@@ -11,3 +11,7 @@ Het prototype van MOZa is bedoeld om ideeën van het team en functionaliteiten t
 Klik hier om de website te bezoeken: [MijnOverheid Zakelijk](https://moza.mijnoverheidzakelijk.nl)
 
 Wil je meer weten over hoe MOZa tot stand komt? Kijk dan op onze GitHub: [GitHub MijnOverheid Zakelijk](https://github.com/MinBZK/moza-portaal)
+
+## Ontwikkeling en vormgeving
+
+Het uiterlijk van het portaal is grotendeels gebaseerd op de MijnOverheid.nl omgeving. Er is niet een bruikbare set componenten die we voor MOZa kunnne hergebruiken (en zal MijnOverheid.nl in 2027 overstappen op een ander design systeem). Hierdoor zijn we aan het kijken wat de beste aanpak is om eenvoudig componenten te kunnen bouwen binnen een [design systeem](design-systeem.md).

--- a/content/onderwerpen/portaal/design-systeem.md
+++ b/content/onderwerpen/portaal/design-systeem.md
@@ -1,0 +1,65 @@
+---
+title: "Design systeem"
+description: "Welk design systeem gebruiken we voor de front-end van het portaal?"
+---
+
+## Wat is een design systeem?
+
+Een design systeem is een samenhangende set van herbruikbare UI-componenten, richtlijnen en design tokens die zorgen voor consistentie in vormgeving en gedrag. Het helpt teams sneller en betrouwbaarder te bouwen doordat visuele en interactieve regels centraal worden beheerd en hergebruikt.
+Dit is specifiek van belang vanuit de gedachte dat de overheid één herkenbare vormgeving voor de burgers en ondernemers wil presenteren.
+
+## Waar moet het design systeem aan voldoen voor MOZa?
+
+Uiteindelijk moet het MOZa project in beheer genomen worden door Logius. Hiervoor zijn een serie eisen opgesteld waaraan het project moet voldoen. Specifiek voor de front-end komt dat neer op:
+
+- Taal: Typescript
+- Front-end framework: Next.JS (met App router)
+- Library: React
+- Design systeem: Lux design system
+
+Deze laatste eis wordt momenteel onderzocht. In het overdracht-document staat namelijk:
+
+> Front-end onderdelen moeten gebruikmaken van het Logius Design System (LUX). Op het moment van schrijven zijn de LUX React-componenten nog niet compatibel met Next.js.
+> Zolang dit het geval is, geldt:
+>
+> - Gebruik LUX design tokens voor kleuren, typografie en spacing;
+> - Maak geen gebruik van eigen styling frameworks of externe UI-bibliotheken;
+> - Componenten worden zo opgezet dat ze in de toekomst eenvoudig geïntegreerd kunnen worden in LUX (conform het Open-Tenzij beleid).
+
+## Wat is het LUX design system?
+
+Het [LUX design system](https://github.com/nl-design-system/lux) staat voor **Logius User eXperience** en is gebaseerd op het NLDS. Het [RHC-nlds](https://www.rijkshuisstijl-community.nl/) - De Rijkshuisstijl Community Design System - doet hetzelfde.
+Bij navraag bij de developers bij team UX (onderdeel van KOOP) is het volgende gemeld:
+
+> Wij onderhouden zowel LUX-ds als RHC-nlds. Sinds een jaar is uitgesproken dat het beter zou zijn als LUX-ds deprecated gemaakt zou worden, zodat de focus volledig kan liggen op RHC-nlds (in praktijk is dit al bijna zo). Ook binnen Logius wordt nu al (onofficieel) geadviseerd om RHC-nlds te gebruiken.
+> Er is wel de LUX design tokens set (hier werd in het overdracht document naar gerefereerd): een reeks van kleuren en afstanden, waardoor je eigen specificaties kunt definiëren bovenop RHC-nlds.
+
+## Kunnen we het RHC-nlds gebruiken?
+
+In het begin van het MOZa project is uitgebreid gekeken naar RHC-nlds. Het project is echter nog niet volwassen genoeg om breed te gebruiken. We zijn voor een paar maanden aangehaakt bij de ontwikkeling van RHC-nlds om te zien of we iets konden bijdragen (en ervoor konden zorgen dat het design systeem bruikbaarder zou worden voor MOZa). Zoals bescheven in [dit document](mox-nlds.md) zijn er echter een aantal fundamentele problemen in de kern-opzet van RHC-nlds, waardoor we tot nu toe gewerkt hebben aan een eigen systeem (Het **MOX-nlds**). Er is nu in het team-overleg besloten om opnieuw te kijken naar wat er mogelijk is in de bestaande design systemen, om te voorkomen dat er meerdere teams aan verschillende dingen werken maar eigenlijk hetzelfde doen.
+
+## Alternatief: NLDD Design System
+
+Er is binnen de overheid nog iemand bezig met het ontwikkelen van een design systeem wat bedoeld is als de de-facto keuze voor het opzetten van front-end in Rijksoverheids applicaties:
+
+[NLDD Design system](https://github.com/MinBZK/storybook): Het design systeem van de Nederlandse Digitale Dienst / Regelrecht. Dit wordt beheerd door [Bart van den Biezen](https://github.com/bartvandebiezen).
+
+Dit systeem is echter niet voor React componenten gebouwd, maar voor Vue. Ook voldoet het niet aan de Rijkshuisstijl. Dit zal dus niet gaan werken met MOZa, omdat we verplicht zijn in React te werken vanuit Logius.
+
+## Vergelijking: Logius eisen vs. bestaande systemen
+
+| Logius vereisten | RHC-nlds | NLDD Design system |
+| ---------------- | :------: | :----------------: |
+| Typescript       |    ✓     |         ✗          |
+| React            |    ✓     |         ✗          |
+| Next.JS          |   ✗ \*   |         ✗          |
+
+(\*) Opmerking: RHC-nlds is op dit moment nog niet goed compatibel met Next.JS `Links` en andere typische Next-componenten zoals `Image`. Datzelfde geldt voor React server components. Dit zorgt op dit moment nog voor veel extra noodzaak om dingen custom te bouwen.
+
+## Conclusie
+
+Zodra we MOZa overdragen aan Logius, is RHC-nlds wellicht volledig ontwikkeld en bruikbaar. Tot die tijd moeten we echter een strategie volgen om overstappen op RHC-nlds zo pijnloos mogelijk te maken.
+
+Op dit moment is het portaal gebouwd door custom CSS en Tailwind-classes.
+We gaan kijken in hoeverre we de LUX design-tokens al kunnen gebruiken.
+Een poging om al deels componenten van RHC-nlds te gebruiken wordt verder onderzocht. Er zijn nog wel een aantal fundamentele problemen bij RHC-nlds, die we met MOX-nlds wilden oplossen. Het idee is nu om toch een tussenvorm te vinden. Er wordt nog besproken of we daarvoor een grotere rol willen spelen bij de Rijkshuisstijl Community.

--- a/content/onderwerpen/portaal/mox-nlds.md
+++ b/content/onderwerpen/portaal/mox-nlds.md
@@ -1,11 +1,11 @@
 ---
-title: "MOX-nlds"
-description: "Ons design systeem voor consistente & stabiele React componenten"
+title: "MOX-nlds (gestopt)"
+description: "Een alternatief idee voor een eigen design systeem"
 ---
 
 ## Wat is MOX-nlds?
 
-MOX-nlds is een design systeem voor de ontwikkeling van de [MijnOverheid Zakelijk portaal](portaal). In potentie kan het systeem ook ingezet worden voor andere interfaces binnen het MijnOverheid Zakelijk ecosysteem (zoals b.v. deze website).
+MOX-nlds is een design systeem voor de ontwikkeling van de [MijnOverheid Zakelijk portaal](../_index.md). In potentie kan het systeem ook ingezet worden voor andere interfaces binnen het MijnOverheid Zakelijk ecosysteem (zoals b.v. deze website).
 Een design systeem is een verzameling van herbruikbare componenten, richtlijnen en standaarden die consistentie en efficiëntie bevorderen in het ontwerp en de ontwikkeling van digitale producten. Omdat we de vormgeving baseren op de richtlijnen van de Rijkshuisstijl, is MOX-nlds naast MOZa producten ook (uiteindelijk) te gebruiken voor andere webapplicaties/websites, zoals b.v. [Mijn Overheid](https://mijnoverheid.nl), [PRO websites](https://www.platformrijksoverheidonline.nl/). In principe alles dat moet voldoen aan de Rijkshuisstijl.
 
 ## Rijkshuisstijl Community Design Systeem / NLDS
@@ -21,6 +21,7 @@ Momenteel is het [Rijkshuisstijl Community Design Systeem](https://www.rijkshuis
 Momenteel is het RHC-nlds nog in ontwikkeling. De manier waarop RHC-nlds opgezet is zorgt echter voor een aantal problemen waardoor MijnOverheid Zakelijk er niet goed mee kan werken:
 
 - De componenten zijn zeer inconsistent in styling, kwaliteit, naamgeving en gebruik. Dit komt door het estafettemodel waar componenten uit diverse hoeken komen, maar een centrale controle-check ontbreekt.
+- Er moeten dingen gehackt worden om te gebruiken binnen het framework waarin het portaal opgezet is (Next.js).
 - De design-tokens (`JSON`) zijn opgezet voor _elk_ component, wat een wildgroei heeft opgeleverd. De hoeveelheid is zo groot dat we er niet goed meer mee overweg kunnen.
 - Tegelijkertijd missen de componenten vaak weer nét de dingen die je zou willen aanpassen.
 - Aanpassen van componenten is lastig: een simpel tekst-blok in een `<Badge>` kan compleet anders werken dan een tekst-blok in een `<Button>` en vaak moet je custom zelf iets bouwen. Design-tokens gebruiken voor consistente vormgeving is daarbij link: deze veranderen vaak, waardoor je styling zal breken zonder dat je dat weet.
@@ -73,7 +74,7 @@ Zie voor meer informatie de Storybook: [Scaling systeem](https://minbzk.github.i
 
 ## Werkwijze & status
 
-Momenteel verkeert het MOX-nlds nog in een alpha-versie.
+Momenteel verkeert het MOX-nlds nog in een alpha-versie en is besloten om de ontwikkeling verder tijdelijk **stop te zetten** om te zien of andere designsystemen gebruikt kunnen worden (RHC-nlds en NLDD Design systeem wat gebruiikt wordt door Regelrecht).
 
 Er wordt via het [prototype](https://www.mijnoverheidzakelijk.nl/onderwerpen/ontwerpprincipes/) gewerkt aan componenten die getest worden in UX-onderzoeken. Zodra een component qua design goed bevonden is, kan het verwerkt worden tot een component in MOX-nlds. Momenteel zijn er al een aantal componenten klaar.
 


### PR DESCRIPTION
Aanpassing op de 'portaal' onderwerp pagina met 2 subpagina's:
- design systemen (hier kijken we naar de NLDD Design system en RHC-nlds mogelijkheden)
- MOX-nlds (gestopt)

<img width="827" height="1189" alt="image" src="https://github.com/user-attachments/assets/4c06ebad-829a-4e97-89ec-603f8d157068" />
