### PR TITLE
Toon laatst-bijgewerkt-datum op onderwerpenpagina's

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -7,3 +7,6 @@ IgnoreURLs:
   - github.com/MinBZK/moza-mcp-standaard-poc
   - claude.ai
   - medium.com
+  - fieldlab.bzlg.apps.digilab.network
+  - styledictionary.com
+  - smashingmagazine.com

--- a/assets/css/components/footer.css
+++ b/assets/css/components/footer.css
@@ -1,4 +1,4 @@
-footer {
+body > footer {
   display: flex;
   flex-direction: column;
   width: 100%;

--- a/assets/css/components/page-nav.css
+++ b/assets/css/components/page-nav.css
@@ -2,8 +2,6 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--color-border);
 }
 
 .page-nav a {

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -90,6 +90,17 @@ article > header:has(.toc-toggle) {
   }
 }
 
+article > footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+}
+
+article > footer p {
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
 button.toc-toggle {
   flex-shrink: 0;
   display: none; /* Verberg standaard op kleine schermen */

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -2,7 +2,7 @@ FROM alpine:3.21 AS builder
 
 ARG HUGO_VERSION=0.154.4
 
-RUN apk add --no-cache wget nodejs npm chromium \
+RUN apk add --no-cache wget git nodejs npm chromium \
     && wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-amd64.tar.gz \
     && tar -xzf hugo.tar.gz -C /usr/local/bin \
     && rm hugo.tar.gz

--- a/content/onderwerpen/_index.md
+++ b/content/onderwerpen/_index.md
@@ -1,3 +1,5 @@
 ---
 title: "Onderwerpen"
+cascade:
+  show_lastmod: true
 ---

--- a/content/onderwerpen/ontwerpprincipes/ontwerp-wat.md
+++ b/content/onderwerpen/ontwerpprincipes/ontwerp-wat.md
@@ -58,7 +58,7 @@ Het ontwerp volgt [de Rijkshuisstijl](https://www.rijkshuisstijl.nl/): de visuel
 
 ### 3. Design tokens als gedeelde taal
 
-[Design tokens](https://www.designtokens.org/tr/drafts/format/) vormen de brug tussen ontwerp en ontwikkeling. Ontwerp-waarden zoals kleuren, typografie en maatvoering zijn opgeslagen in een centraal JSON-bestand (`tokens.json`) dat zowel vanuit Figma (via [Tokens Studio](https://tokens.studio/)) als vanuit de code bewerkt kan worden.
+[Design tokens](https://www.w3.org/community/design-tokens/) vormen de brug tussen ontwerp en ontwikkeling. Ontwerp-waarden zoals kleuren, typografie en maatvoering zijn opgeslagen in een centraal JSON-bestand (`tokens.json`) dat zowel vanuit Figma (via [Tokens Studio](https://tokens.studio/)) als vanuit de code bewerkt kan worden.
 
 - **Twee lagen** – de [tokens zijn opgedeeld](https://medium.com/eightshapes-llc/tokens-in-design-systems-25dd82d58421) in _opties_ (de beschikbare waarden uit de Rijkshuisstijl) en _toepassingen_ (semantische verwijzingen die bepalen hoe de opties worden ingezet). In de code worden altijd toepassingsvariabelen gebruikt, nooit opties rechtstreeks.
 - **Eén bron van waarheid** – alle ontwerp-waarden leven in `tokens.json`. [Style Dictionary](https://styledictionary.com/) vertaalt deze naar CSS custom properties. De gegenereerde CSS-bestanden worden niet handmatig aangepast.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -15,6 +15,7 @@ disableKinds:
   - term
 
 enableRobotsTXT: true
+enableGitInfo: true
 
 permalinks:
   page:

--- a/layouts/_partials/article.html
+++ b/layouts/_partials/article.html
@@ -35,31 +35,38 @@
     {{- end -}}
   </header>
   {{ .Content }}
-  {{- if gt $navCount 1 -}}
-    {{- $isFirst := eq $currentIdx 0 -}}
-    {{- $isLast := eq $currentIdx (sub $navCount 1) -}}
-    {{- $parent := index $navList 0 -}}
-    <nav class="page-nav" aria-label="Navigatie binnen deze reeks">
-      {{- if not $isFirst -}}
-        {{- $prev := index $navList (sub $currentIdx 1) -}}
-        <a href="{{ $prev.RelPermalink }}" rel="prev" class="page-nav-prev">
-          <span class="page-nav-label">Vorige</span>
-          <span class="page-nav-title">{{ $prev.Params.card_title | default $prev.Title }}</span>
-        </a>
-      {{- end -}}
-      {{- if $isLast -}}
-        <a href="{{ $parent.RelPermalink }}" class="page-nav-next">
-          <span class="page-nav-label">Terug naar</span>
-          <span class="page-nav-title">{{ $parent.Params.card_title | default $parent.Title }}</span>
-        </a>
-      {{- else -}}
-        {{- $next := index $navList (add $currentIdx 1) -}}
-        <a href="{{ $next.RelPermalink }}" rel="next" class="page-nav-next">
-          <span class="page-nav-label">Volgende</span>
-          <span class="page-nav-title">{{ $next.Params.card_title | default $next.Title }}</span>
-        </a>
-      {{- end -}}
-    </nav>
+  {{- if or .Params.show_lastmod (gt $navCount 1) -}}
+  <footer>
+    {{- if .Params.show_lastmod -}}
+    <p>Deze pagina is voor het laatst bijgewerkt op <time datetime="{{ .Lastmod.Format "2006-01-02" }}">{{ .Lastmod | time.Format ":date_full" }}</time>.</p>
+    {{- end -}}
+    {{- if gt $navCount 1 -}}
+      {{- $isFirst := eq $currentIdx 0 -}}
+      {{- $isLast := eq $currentIdx (sub $navCount 1) -}}
+      {{- $parent := index $navList 0 -}}
+      <nav class="page-nav" aria-label="Navigatie binnen deze reeks">
+        {{- if not $isFirst -}}
+          {{- $prev := index $navList (sub $currentIdx 1) -}}
+          <a href="{{ $prev.RelPermalink }}" rel="prev" class="page-nav-prev">
+            <span class="page-nav-label">Vorige</span>
+            <span class="page-nav-title">{{ $prev.Params.card_title | default $prev.Title }}</span>
+          </a>
+        {{- end -}}
+        {{- if $isLast -}}
+          <a href="{{ $parent.RelPermalink }}" class="page-nav-next">
+            <span class="page-nav-label">Terug naar</span>
+            <span class="page-nav-title">{{ $parent.Params.card_title | default $parent.Title }}</span>
+          </a>
+        {{- else -}}
+          {{- $next := index $navList (add $currentIdx 1) -}}
+          <a href="{{ $next.RelPermalink }}" rel="next" class="page-nav-next">
+            <span class="page-nav-label">Volgende</span>
+            <span class="page-nav-title">{{ $next.Params.card_title | default $next.Title }}</span>
+          </a>
+        {{- end -}}
+      </nav>
+    {{- end -}}
+  </footer>
   {{- end -}}
 </article>
 {{- if $hasToc -}}


### PR DESCRIPTION
## Wat
Op pagina's onder `/onderwerpen` verschijnt onderaan het artikel:

> Deze pagina is voor het laatst bijgewerkt op *dinsdag 24 februari 2026*.

## Hoe
- `enableGitInfo: true` zodat `.Lastmod` de laatste git-commitdatum is (i.p.v. de bestands-mtime)
- `show_lastmod` cascade-param op `onderwerpen/_index.md` — herbruikbaar voor andere secties zonder template-aanpassing
- Template-check is `and .Params.show_lastmod (eq .Kind "page")` — sluit ook geneste sectiepagina's (zoals `ontwerpprincipes/`) en alias-redirects uit
- Eigen CSS-component `assets/css/components/laatste-update.css`, footer-stijl met scheidingslijn (`border-top` via `--color-border` token)

## Inbegrepen onderhoud (aparte commit)
- Design tokens-link op `ontwerpprincipes/ontwerp-wat`: oude URL `designtokens.org/tr/drafts/format/` had TLS-fout, vervangen door de W3C Community Group-pagina
- `fieldlab.bzlg.apps.digilab.network` toegevoegd aan `.htmltest.yml` `IgnoreURLs` (retired host, kwam voor in 6 archief-weeklies van okt/nov 2025)