### PR TITLE
MOZa Weekly 27 mei 2026

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -11,3 +11,4 @@ IgnoreURLs:
   - styledictionary.com
   - smashingmagazine.com
   - code.overheid.nl
+  - realisatieibds.pleio.nl

--- a/content/weekly/2026/2026-05-20.md
+++ b/content/weekly/2026/2026-05-20.md
@@ -95,7 +95,7 @@ Het team van MOZa heeft genoten van vakantiedagen, maar heeft tussendoor niet st
 * MOZa Pulse - 21 mei
 * Stuurgroep - 22 mei
 * Regieteam - 4 juni
-* Dag van de Publieke Dienstverlening - 18 juni - MOZa verzorgt een workshop
+* Dag van de Publieke Dienstverlening - 17 juni - MOZa verzorgt een workshop
 * [Dag van de toekomst: ondernemer centraal](https://digilab.pleio.nl/groups/view/c182ef44-4cf1-4912-9afa-da3e8b509f32/evenementen-algemeen/events/view/969b45cd-7057-4251-a949-32214fe43663/dag-van-de-toekomst-ondernemer-centraal-en-regeldruk) - 18 juni - MOZa samen met Digilab
 
 **Evenementen**

--- a/content/weekly/2026/2026-05-27.md
+++ b/content/weekly/2026/2026-05-27.md
@@ -1,0 +1,80 @@
+---
+title: MOZa Weekly 27 mei 2026
+date: 2026-05-27
+---
+
+## Algemeen
+
+* **MOZa Pulse 21 mei:** in de pulse stonden de demonstratie van Gemeente Amsterdam over de [profielservice](/onderwerpen/profielservice/) tijdens het [Common Ground Fieldlab](https://commonground.nl/events/view/df0a6e7b-2b9c-4fef-93e2-9b6d88ee34b3/common-ground-fieldlab-11-en-12-mei-2026) en de inzichten uit het gebruikersonderzoek van eind april centraal.
+* **Stuurgroep MOZa 22 mei:** de stuurgroep is bijeengekomen, waarbij we onder andere stil hebben gestaan bij wat is gedaan in [fase 3](/documenten/rapportages/statusrapport-moza-fase-3/) en wat de [plannen voor fase 4](/documenten/rapportages/plan-moza-fase-4/) zijn. Daarbij is benadrukt dat de prioriteit blijft liggen op notificeren, profiel en berichten. Daarnaast zijn we scherp op hoe we juridische processen zo snel mogelijk kunnen doorlopen, zodat dit aansluit bij het tempo dat we technisch maken.
+* **Vernieuwingsvoorstel GDI 2027:** er waren vragen binnengekomen of we op een aantal punten extra toelichting konden geven. Een nieuwe versie is ingediend en het is nu even afwachten of dit voldoende is, of dat er nog een uitnodiging komt om mondeling nog vragen te beantwoorden.
+
+## Profielservice
+
+* **Werksessie profielservice en notificatiedienst:** in een vervolgsessie met Logius en BZK hebben we met elkaar gekeken of we op hoofdlijnen dezelfde beelden hebben. Daarbij hadden we ook aandacht voor zaken die nog uitgezocht moeten worden, en voor zaken waarvan we nu al weten dat ze juridisch geregeld moeten worden. Het is goed te zien dat deze beelden worden gedeeld en we samen vooruit komen.
+* **Common Ground-aanpassingen verwerkt:** de wijzigingen aan het gegevensmodel die we tijdens het Common Ground Fieldlab bespraken zijn doorgevoerd. De aanpassingen staan in de [documentatie van de profielservice](https://docs.mijnoverheidzakelijk.nl/workspace/documentation/Profiel%20Service).
+* **Twee versies naast elkaar:** in onze acceptatieomgeving draaien nu meerdere versies van de profielservice tegelijk. Zo kunnen we soepel eerst vergelijken en daarna aanpassingen doorvoeren.
+* **Database-migraties met Flyway:** we kozen Flyway als tooling voor onze database-migraties. We leggen deze keuze nog vast in een beslisdocument.
+* **Eisen centraal:** de eisen voor de profielservice zijn samengebracht op één centrale plek, zodat nieuwe wensen daar terechtkomen.
+* **Levensgebeurtenis overlijden:** in vervolg op een eerder gesprek met ICTU spraken we ook met KVK over hoe de profielservice een rol kan spelen na overlijden van een ondernemer.
+
+## Notificatiedienst
+
+* **Van service naar dienst:** we werken aan overheidsbrede interactieservices, maar rondom notificeren is de conclusie dat we eigenlijk een notificatiedienst aan het realiseren zijn. Met onze collega's is afgesproken dat we het daarom voortaan "notificatiedienst" noemen.
+* **Notificatie Management Component (NMC):** het NMC krijgt een eigen plek binnen de notificatiedienst en de eerste eisen zijn op een rij gezet. Stap voor stap verzamelen we wensen en eisen voor deze nieuwe dienst.
+* **Implementatieplan:** samen met Obis zijn we gestart met een implementatieplan voor de notificatiedienst. De komende periode vullen we dit verder in.
+* **Logius PI planning 10 & 11 juni:** we bereiden ons voor op de PI planning. Voor de notificatiedienst is dit relevant, omdat er ook onderdelen worden gerealiseerd door Logius. Dit stemmen we goed met elkaar af.
+* **Toegang tot Logius omgeving:** met Logius bespraken we hoe wij toegang krijgen tot de Logius Project Cloud. Dat proces is in gang gezet.
+
+## Berichten / FBS
+
+* **Berichtenmagazijn uitgebreid:** de [proefopstelling Federatief Berichtenstelsel](https://minbzk.github.io/moza-poc-fbs-berichtenbox/) is uitgebreid met een Ophaal- en Beheer-API, een publicatiestream en een bericht-validatieservice.
+* **AI-verantwoording:** we hebben een AI-verantwoording toegevoegd aan onze ontwikkelpraktijk.
+* **Belastingdienst als pilot:** in een kennismakingsgesprek gaf de Belastingdienst aan als pilotorganisatie te willen meewerken aan het FBS. Zij gaan aan de slag met hun eisen. Onze opzet sluit aan op een verkenning die zij eerder zelf deden.
+* **WeAreFrank:** we maakten kennis met WeAreFrank, die intensief samenwerkt met veel gemeenten. Zij kunnen later helpen bij pilots.
+* **Hackathon-container:** de [veilige dev-container](https://github.com/RijksICTGilde/hackathon-claude-code) waarin we Claude Code inzetten kreeg een script voor een lokale Maven MCP-host en een auto-startup van de Docker-container.
+* **UX/UI design:** in een overleg bespraken we de UX/UI-uitwerking voor de proefopstelling van het FBS.
+
+## Digitale Assistent
+
+* **Stakeholdermapping:** we brachten de stakeholders rond de [Digitale Assistent](https://proef.moza.rijksapp.dev/moza/digitale-assistent/) in kaart.
+* **Hosting en modellen:** we maakten een overzicht van mogelijke hosting en modellen. Met SSC-ICT Vlam verkennen we hoe we de samenwerking kunnen opzetten.
+* **MKBot en DAO:** we testten MKBot. De vraag die bij ons opkwam: is het logisch om MKBot en DAO als gescheiden bots aan te bieden, of brengen we dit beter samen?
+
+## Machine-uitvoerbare wetgeving
+
+* **[RegelRecht](https://regelrecht.rijks.app/) en RVO Financieel CV:** we hadden de eerste inhoudelijke sessie en hebben met elkaar de scope bepaald. We starten met de wet banenafspraak en quotum arbeidsbeperkten. In deze eerste iteratie nemen we de twee meest gebruikte ingangen naar het UWV-doelgroepregister mee: Wajong en Participatiewet. De WIA-route, WW-route en overige LKV-categorieën komen in een volgende iteratie.
+* **[RegelRecht](https://regelrecht.rijks.app/) en CSRD:** ook met het CSRD-team van RVO was er een eerste inhoudelijke sessie. RegelRecht sluit goed aan op de huidige set-up. Wel werd duidelijk dat we scherper moeten maken hoe het eindproduct eruit gaat zien. Daarvoor staat een brainstorm met het RVO-team gepland.
+
+## Agenda
+
+💡 Wist je dat we (bijna) elke maandag samenwerken op het Beatrixpark in Den Haag? Wil je een keer aanhaken, dan ben je van harte welkom.
+
+**MOZa**
+
+* VNG MijnServices Festival - 28 mei - MOZa staat op de vloer en verzorgt presentaties / demo's
+* Teamoverleg - 3 juni
+* Regieteam - 4 juni (wordt mogelijk verplaatst naar Logius PI event)
+* Logius PI planning - 10 & 11 juni
+* Dag van de Publieke Dienstverlening - 17 juni - MOZa verzorgt een workshop
+* MOZa Pulse - 18 juni
+* [Dag van de toekomst: ondernemer centraal](https://digilab.pleio.nl/groups/view/c182ef44-4cf1-4912-9afa-da3e8b509f32/evenementen-algemeen/events/view/969b45cd-7057-4251-a949-32214fe43663/dag-van-de-toekomst-ondernemer-centraal-en-regeldruk) - 18 juni - MOZa samen met [Digilab](https://digilab.overheid.nl/)
+* UX-onderzoeksdag - 22 juni
+* Stuurgroep - 16 juli
+
+**Evenementen**
+
+* Demo usecase verificatie QTSP - project UBO/BronConnect - 28 mei
+* [Symposium European Business Wallet](https://ecp.nl/agenda/symposium-de-european-business-wallet-het-fundament-voor-een-concurrerend-digitaal-bedrijfsleven/) (ECP, Jaarbeurs) - 2 juni
+* Werkgroep MijnZaken/MijnTaken (Obis) - 2 juni
+* Webinar Standaarden in het Federatief Datastelsel - 4 juni
+* [OneGov AI Hackathon Series](https://www.digitaleoverheid.nl/evenementen/onegov-ai-hackathon-series/) - 4 & 5 juni (pre-hackathon op 29 mei)
+* [Common Ground Congres](https://commonground.nl/events/view/919890aa-dd01-488c-bbba-8d6c197e9b0f/common-ground-congres-8-juni-2026) - 8 juni
+* [FOST Amsterdam](https://apidays.global/fost-events/amsterdam) - 9 & 10 juni (developer.overheid.nl verzorgt een API- en Open Source-track)
+* [GovTech Day](https://www.digitaleoverheid.nl/evenementen/govtech-day/) - 11 juni
+* [Overheid360°](https://www.digitaleoverheid.nl/evenementen/overheid360/) (Jaarbeurs Utrecht) - 17 juni
+* Developer.overheid.nl meetup - 17 juni
+* Werkgroep standaarden en architectuur (Obis) - 18 juni
+* [Samen versnellen met AI: de overheid van morgen begint nu](https://www.aanmelder.nl/174738) - 25 juni
+* [Dag van de Digitale Toegankelijkheid](https://dagvandedigitaletoegankelijkheid.nl/) - 28 juni
+* Common Ground Fieldlab - 14 & 15 september


### PR DESCRIPTION
## Samenvatting

Nieuwe MOZa Weekly van 27 mei 2026. Hoofdpunten:

- Naam "notificatiedienst" is definitief vastgesteld met Logius.
- Belastingdienst wil meewerken als pilotorganisatie voor het Federatief Berichtenstelsel.
- RegelRecht-traject met RVO Financieel CV gestart op de Wet banenafspraak en quotum arbeidsbeperkten (Wajong + Participatiewet als eerste iteratie).
- Profielservice: gegevensmodelaanpassingen uit Common Ground Fieldlab verwerkt, ACC-omgeving draait twee versies parallel, Flyway gekozen voor migraties.
- Berichtenmagazijn uitgebreid met Ophaal- en Beheer-API, publicatiestream en bericht-validatieservice.

## Wijzigingen

- `content/weekly/2026/2026-05-27.md` toegevoegd.
- `content/weekly/2026/2026-05-20.md`: datum Dag van de Publieke Dienstverlening gecorrigeerd van 18 naar 17 juni.
- `.htmltest.yml`: `realisatieibds.pleio.nl` toegevoegd aan ignore-lijst (geeft 503-fouten op niet-aangeraakte pagina's).

## Test plan

- [x] `hugo` build slaagt
- [x] Pre-commit hooks (htmltest + hugo-build) slagen
- [ ] Visuele check op staging