### PR TITLE
MOZa Weekly 3 juni 2026

### DIFF
--- a/content/weekly/2026/2026-06-03.md
+++ b/content/weekly/2026/2026-06-03.md
@@ -1,0 +1,88 @@
+---
+title: MOZa Weekly 3 juni 2026
+date: 2026-06-03
+---
+
+## Algemeen
+
+* **MOZa event:** vergeet je niet om je aan te melden voor de [Dag van de toekomst: ondernemer centraal](https://digilab.pleio.nl/groups/view/c182ef44-4cf1-4912-9afa-da3e8b509f32/evenementen-algemeen/events/view/969b45cd-7057-4251-a949-32214fe43663/dag-van-de-toekomst-ondernemer-centraal-en-regeldruk) op 18 juni vanaf 12:00.
+* **[VNG MijnServices Festival](https://www.digitaleoverheid.nl/evenementen/mijnservices-festival/):** op 28 mei stonden we op de vloer met presentaties en demo's. We voerden veel goede gesprekken, onder andere over (business) wallets en het delen van gegevens van nutsbedrijven met de overheid. De komende tijd gaan we deze gesprekken opvolgen en verdiepingen plannen.
+* **Routekaartoverleg MijnOverheid:** op basis van het [statusrapport fase 3](/documenten/rapportages/statusrapport-moza-fase-3/) gaven we een update over wat we hebben gedaan. Daaraan koppelden we een samenvatting van onze [plannen voor fase 4](/documenten/rapportages/plan-moza-fase-4/). Zo delen we de plannen voor MijnOverheid breder. Stap voor stap brengen we zaken bij elkaar.
+* **Nieuwe collega's:** er zijn nieuwe collega's gestart. Van harte welkom! Een mooi moment om onze [onboarding-flow te testen en aan te scherpen](/handboek/jouw-start/).
+
+## Gebruikersonderzoek
+
+* **Iets nieuws:** in onze werkwijze zetten wij de [ondernemer centraal](/handboek/werkwijze/principes/#ondernemer-centraal). Daarom deze week iets nieuws: ons eerste guerrilla-onderzoek. We gaan naar een locatie en gaan daar in gesprek met ondernemers en burgers. Zo horen we hoe zij tegen onderwerpen aankijken.
+* **Guerrilla-onderzoek in Den Haag:** we spraken negen mensen "in het wild" bij een kringloopwinkel. We wilden weten of mensen last hebben van een doorverwijzing naar MOZa bij het inloggen vanaf overheid.nl en mijn.overheid.nl. Het antwoord: nee, daar hebben ze geen last van.
+* **Volgende stappen:** volgende week leggen we een vergelijkbare vraag voor aan ondernemers bij de KVK in Rotterdam. Ook willen we op 18 juni ondernemers spreken in Arnhem.
+* **Prototype uitgebreid:** voor dit onderzoek bouwden we de inlogflow "Uniform inloggen" van Figma om naar een HTML-prototype. We voegden ook een [fictieve inlogflow](https://proef.moza.rijksapp.dev/inloggen/) en [een fictieve mailbox](https://proef.moza.rijksapp.dev/mailbox/) toe aan het prototype.
+* **Browser-extensie:** we maakten een browser-extensie waarmee we links op bestaande pagina's kunnen aanpassen of toevoegen. Zo kunnen we bijvoorbeeld op een pagina van de KVK of RVO een verwijzing naar MOZa tonen en testen hoe mensen daarop reageren.
+* **MijnKVK:** in een gesprek met het UX-team van MijnKVK verkenden we wat we voor elkaar kunnen betekenen. We houden elkaar voorlopig op de hoogte van de ontwikkelingen.
+
+## Profielservice
+
+* **Sprint afgerond:** we rondden alle issues uit de sprint af. In de nieuwe sprint ligt de focus op het verder verbeteren van de [profielservice](/onderwerpen/profielservice/) en het onderzoeken van inlogmethoden.
+* **Pentest in voorbereiding:** we bereiden een pentest voor en die staat met potlood ingetekend voor eind september. We willen daarmee in elk geval de profielservice en het Notificatie Management Component laten toetsen.
+* **Hosting in de Logius Project Cloud:** in een sessie met Logius bespraken we het hosten van de profielservice in de Logius Project Cloud. Daaruit kwamen randvoorwaarden en acceptatiecriteria, die we nu omzetten in concrete stories.
+* **Documentatie aangevuld:** we werkten [de documentatie](https://docs.mijnoverheidzakelijk.nl/workspace/documentation/Profiel%20Service) bij over database-migraties, over authenticatie en autorisatie op de Logius Project Cloud, en over ons secret-management.
+* **LDV-validatie:** we maakten een validatie voor het Logboek Dataverwerkingen met behulp van AI-skills. Deze staat klaar om na te kijken.
+* **Demo Gemeente Amsterdam:** we ondersteunden Gemeente Amsterdam bij hun demo op het VNG MijnServices Festival.
+
+## Notificatiedienst
+
+* **Notificatie Management Component (NMC):** het NMC krijgt een eigen plek binnen de notificatiedienst. De eisen leggen we vast op een centrale requirements-pagina, zodat nieuwe wensen daar terechtkomen. Deze publiceren we binnenkort op de MOZa-site.
+* **Implementatieplan:** samen met Obis vullen we het implementatieplan voor de notificatiedienst verder in. Dit is ook de voorbereiding op de Logius PI planning van 10 en 11 juni. We brengen in kaart bij wie we tijd moeten reserveren.
+* **Afstemming:** we voerden veel gesprekken met Logius en de Belastingdienst. Het beeld dat wij hebben bij de profielservice en notificatiedienst sluit goed aan bij dat van de Belastingdienst.
+
+## Architectuur
+
+* **Beschrijvende architectuur:** we werken aan de beschrijvende architectuur in een positioneringsdocument. We bespraken een tussenversie en verwerken de aanscherpingen. We voegen een hoofdstuk toe over de interactiediensten uit het cluster Bereikbaarheid: profiel-registratie, autorisatie-verlening, notificatie-management en berichten-administratie.
+
+## Berichten / FBS
+
+* **Stakeholdermapping en presentatie:** we werkten aan een stakeholdermapping en aan een presentatie. Daarmee nemen we belanghebbenden mee in wat we doen en enthousiasmeren we hen.
+* **Federatief, geen centrale lijst:** in gesprekken werd bevestigd dat je in een federatief stelsel liever geen centrale lijst hebt. Dat past goed bij onze aanpak.
+* **Magazijn-resolver:** we hebben een magazijn-resolver toegevoegd aan de [proefopstelling van het Federatief Berichtenstelsel](https://minbzk.github.io/moza-poc-fbs-berichtenbox/). Deze resolver bepaalt uit welke berichtenmagazijnen iemand berichten mag en wil ontvangen. Dit doen we op basis van de profielservice. Machtigingen hebben we hier nog niet in meegenomen.
+* **Uitvraagservice:** de berichten-uitvraagservice is klaar. Die pakken we als volgende op.
+* **Tekst op de site:** we werken aan de tekst voor de pagina over [Berichten](/onderwerpen/berichtenbox/).
+
+## Digitale Assistent
+
+* **Eigen omgeving:** we verhuizen de [Digitale Assistent](/onderwerpen/digitale-assistent/) uit de gezamenlijke proefopstelling naar een [eigen repository](https://github.com/MinBZK/moza-poc-digitale-assistent). We schonen meteen op en voegden een verantwoording over ons AI-gebruik toe.
+* **Demo op het festival:** de demo op het VNG MijnServices Festival ging goed.
+
+## Machine-uitvoerbare wetgeving
+
+* **[RegelRecht](https://regelrecht.rijks.app/) en validatie:** met het validatieteam zetten we een volgende stap in de methode om machine-leesbare wetten te maken en te valideren. We bepaalden samen wat en wie we daarvoor nodig hebben.
+* **Financieel CV:** we zetten de wetten voor Financieel CV in de RegelRecht-editor. Volgende week werken we verder met het team van RVO.
+* **Pionieren met RegelRecht:** op 1 juni hadden we met BZK een sessie over pionieren met RegelRecht. Ook JenV haakte enthousiast aan.
+
+## Agenda
+
+💡 Wist je dat we (bijna) elke maandag samenwerken op het Beatrixpark in Den Haag? Wil je een keer aanhaken, dan ben je van harte welkom.
+
+**MOZa**
+
+* Logius PI planning - 10 & 11 juni
+* Regieteam - 11 juni (tijdens het Logius PI event)
+* Dag van de Publieke Dienstverlening - 17 juni - MOZa verzorgt een workshop
+* MOZa Pulse - 18 juni
+* [Dag van de toekomst: ondernemer centraal](https://digilab.pleio.nl/groups/view/c182ef44-4cf1-4912-9afa-da3e8b509f32/evenementen-algemeen/events/view/969b45cd-7057-4251-a949-32214fe43663/dag-van-de-toekomst-ondernemer-centraal-en-regeldruk) - 18 juni - MOZa samen met [Digilab](https://digilab.overheid.nl/)
+* UX-onderzoeksdag - 22 juni
+* Stuurgroep - 16 juli
+
+**Evenementen**
+
+* Webinar Standaarden in het Federatief Datastelsel - 4 juni
+* [OneGov AI Hackathon Series](https://www.digitaleoverheid.nl/evenementen/onegov-ai-hackathon-series/) - 4 & 5 juni
+* [Common Ground Congres](https://commonground.nl/events/view/919890aa-dd01-488c-bbba-8d6c197e9b0f/common-ground-congres-8-juni-2026) - 8 juni
+* [FOST Amsterdam](https://apidays.global/fost-events/amsterdam) - 9 & 10 juni (developer.overheid.nl verzorgt een API- en Open Source-track)
+* [GovTech Day](https://www.digitaleoverheid.nl/evenementen/govtech-day/) - 11 juni
+* [Overheid360°](https://www.digitaleoverheid.nl/evenementen/overheid360/) (Jaarbeurs Utrecht) - 17 juni
+* Developer.overheid.nl meetup - 17 juni
+* [Dag van de toekomst: ondernemer centraal](https://digilab.pleio.nl/groups/view/c182ef44-4cf1-4912-9afa-da3e8b509f32/evenementen-algemeen/events/view/969b45cd-7057-4251-a949-32214fe43663/dag-van-de-toekomst-ondernemer-centraal-en-regeldruk) - 18 juni - MOZa samen met [Digilab](https://digilab.overheid.nl/)
+* Werkgroep standaarden en architectuur (Obis) - 18 juni
+* [Samen versnellen met AI: de overheid van morgen begint nu](https://www.aanmelder.nl/174738) - 25 juni
+* [Dag van de Digitale Toegankelijkheid](https://dagvandedigitaletoegankelijkheid.nl/) - 28 juni
+* Common Ground Fieldlab - 14 & 15 september
+* Business Wallet B2G - 22 of 23 september


### PR DESCRIPTION
Nieuwe MOZa Weekly van 3 juni 2026.

## Inhoud

Secties: Algemeen, Gebruikersonderzoek, Profielservice, Notificatiedienst, Architectuur, Berichten / FBS, Digitale Assistent, Machine-uitvoerbare wetgeving en Agenda.

Hoogtepunt deze week: ons eerste **guerrilla-onderzoek** — we spraken negen mensen "in het wild" om te toetsen of een doorverwijzing naar MOZa bij het inloggen als hinderlijk wordt ervaren.

## Agenda

- Regieteam verplaatst naar 11 juni (tijdens het Logius PI event).
- Voorbije items verwijderd; Webinar Standaarden in het Federatief Datastelsel (4 juni) en verdere events toegevoegd/behouden.