### PR TITLE
MOZa Weekly 10 juni 2026

### DIFF
--- a/content/weekly/2026/2026-06-10.md
+++ b/content/weekly/2026/2026-06-10.md
@@ -1,0 +1,90 @@
+---
+title: MOZa Weekly 10 juni 2026
+date: 2026-06-10
+---
+
+## Algemeen
+
+* **Onderwerppagina's bijgewerkt:** we werkten verschillende onderwerppagina's bij of voegden deze toe. Het gaat om de pagina's over de [Profielservice](/onderwerpen/profielservice/), [Berichten / FBS](/onderwerpen/berichten-fbs/) en de [Digitale Assistent](/onderwerpen/digitale-assistent/).
+* **Dag van de toekomst: ondernemer centraal:** we zijn druk met de voorbereidingen voor [18 juni](https://digilab.pleio.nl/groups/view/c182ef44-4cf1-4912-9afa-da3e8b509f32/evenementen-algemeen/events/view/969b45cd-7057-4251-a949-32214fe43663/dag-van-de-toekomst-ondernemer-centraal-en-regeldruk). De workshops staan en er zijn leuke sprekers. Je kunt je nog aanmelden. We organiseren deze dag samen met [Digilab](https://digilab.overheid.nl/).
+* **Business wallets:** verschillende collega's bezochten het [Symposium European Business Wallet](https://ecp.nl/agenda/symposium-de-european-business-wallet-het-fundament-voor-een-concurrerend-digitaal-bedrijfsleven/). De rode draad: over een aantal jaar verloopt veel dienstverlening via de wallet, en bijna elke klantreis begint met inloggen. We vinden dit een belangrijk onderwerp en kijken hoe we dit mee gaan nemen in de ontwikkeling als onderdeel van de [proeftuin](/onderwerpen/proeftuin/). Naar aanleiding van het VNG MijnServices Festival is er ook contact geweest met de Gemeente Nijmegen.
+* **Werkgroep MijnZaken/MijnTaken:** we haakten aan bij deze werkgroep van Obis / MOZa om op de hoogte te blijven van de ontwikkelingen. Binnenkort start ook de verkenning vanuit MOZa gericht op het ondernemersdomein. Met het werk dat al wordt verzet, hebben we een mooi vertrekpunt.
+* **ODI:** we praatten het directieteam van [Rijksorganisatie ODI](https://www.rijksorganisatieodi.nl/) bij over MOZa en onze werkwijze. Daarbij ook een hulpvraag neergelegd hoe we op een efficiënte manier van het netwerk van ODI gebruik kunnen maken. Daar gaan we nog opvolging aan geven via het ODI-thema netwerksamenwerking.
+* **Inwerken met AI:** onze open en transparante manier van werken helpt nu nieuwe collega's snel op weg. Een nieuwe collega kan namelijk met Claude als "buddy" in korte tijd veel context over MOZa en onze omgeving krijgen, juist omdat onze informatie open en goed vindbaar is. Zo ontdekken we dat we ook ongepland nieuwe manieren van inwerken verkennen.
+
+## Gebruikersonderzoek
+
+* **Prototype aangescherpt:** we verwerkten inzichten uit eerder onderzoek in het [prototype](https://github.com/MinBZK/moza-poc) en scherpten de content aan voor de volgende doelgroep die we onderzoeken. De wijzigingen volgen elkaar momenteel snel op en houden we daarom bij in een [changelog](https://github.com/MinBZK/moza-poc/blob/main/CHANGELOG.md).
+* **Team gebruikersonderzoek en UX:** het team rond UX en gebruikersonderzoek krijgt steeds meer vorm en heeft vanaf nu ook een eigen product owner. Zo bouwen we aan een uniforme ervaring voor onze gebruikers, zoeken we samenwerking en aansluiting, en delen we inzichten met de andere teams.
+
+## Profielservice
+
+* **Over de profielservice:** de pagina over de [profielservice](/onderwerpen/profielservice/) staat nu echt met de meest recente versie online.
+* **DPIA in de maak:** we werken aan de DPIA voor de profielservice en hebben deze van een update voorzien. We brengen de informatie bij elkaar en houden die begrijpelijk voor een breder publiek.
+* **Richting productie:** we kijken waar we de profielservice verder kunnen professionaliseren, met het oog op productie. Hierover vindt ook afstemming met Logius plaats, zodat we met elkaar een steeds beter beeld krijgen van de kaders en voorwaarden.
+
+## Notificatiedienst
+
+* **Beschrijving aangescherpt:** we scherpen de beschrijving van de notificatiedienst verder aan. Dit is nog werk in uitvoering en wordt binnenkort gepubliceerd.
+* **Logius PI event:** samen met Logius bereiden we het PI event van 10 en 11 juni voor, met onder andere aandacht voor het plan voor de livegang en de postverzending, zodat we contactherstel kunnen organiseren.
+
+## Architectuur
+
+* **Beschrijvende architectuur:** we werkten deze week verder aan de beschrijvende architectuur rondom alles wat met berichten te maken heeft.
+* **Kennismaking Digipoort:** in een kennismaking met Logius over Digipoort zagen we één toepassing die lijkt op wat wij willen: gegevens ophalen bij de Belastingdienst om een aangifte in te vullen. Of dit patroon herbruikbaar is, is nog niet duidelijk.
+
+## Berichten / FBS
+
+* **Pagina over Berichten:** de pagina over [Berichten](/onderwerpen/berichten-fbs/) staat online.
+* **Documentatie:** we hebben ons C4-model over onze implementatie van het [Federatief Berichtenstelsel](https://minbzk.github.io/moza-poc-fbs-berichtenbox/) bijgewerkt. Daarnaast is er een visiedocument in ontwikkeling waar we ook naar gaan kijken.
+* **Techniek:** we troffen voorbereidingen voor een aanmeldservice, maakten de berichtensessiecache lichter (in-process in plaats van via REST) en breidden onze CI/CD-tests uit met checks op codekwaliteit en coverage.
+* **Webinar:** we woonden het webinar Standaarden in het Federatief Datastelsel bij.
+
+## Authenticatie en autorisatie
+
+* **Aftrap:** met een aantal collega's hadden we een aftrap over authenticatie en autorisatie. We bespraken wat er al is en spraken af wie wat verder oppakt. Dit raakt aan de actie mandaten en machtigen uit het [plan voor fase 4](/documenten/rapportages/plan-moza-fase-4/).
+* **Vanuit de klantreis:** we starten met een dagdeel waarin we vanuit een klantreis met persona's nadenken over oplossingsrichtingen, op basis van bestaande informatie. Daarna willen we hier samen met onze stakeholders aan gaan werken.
+
+## Digitale Assistent
+
+* **Pagina over Digitale Assistent:** ook de pagina over [Digitale Assistent](/onderwerpen/digitale-assistent/) staat online.
+* **Verhuizing afgerond:** we rondden de verhuizing van de [Digitale Assistent](/onderwerpen/digitale-assistent/) naar een [eigen omgeving](https://github.com/MinBZK/moza-poc-digitale-assistent) af. De assistent is nog steeds geïntegreerd in de proefopstelling, maar kan nu makkelijker worden doorontwikkeld.
+* **AI-Verordening:** we liepen de beslishulp van de AI-Verordening door voor twee scenario's: in gebruik en in ontwikkeling.
+* **Dag van de toekomst:** we bereiden de demo voor 18 juni voor.
+
+## Regelhulpen, RegelRecht en machine-uitvoerbare wetgeving
+
+* **Demo BZK:** we presenteerden de samenwerking tussen RegelRecht en MOZa aan collega's van BZK en "stiekem" ook JenV met leuke positieve reacties.
+* **Vervolg Regelhulpen:** met RVO en BZK bespraken we het vervolg van de Regelhulpen. Dit sluit aan op de pilots die we nu al doen.
+* **Toekomstbeeld Regelhulpen:** samen met RVO hebben we open gesproken over de eerste stappen richting een toekomstbeeld. Een regelhulp kan een wet of regeling makkelijker uitleggen, als aanvulling op [RegelRecht](https://regelrecht.rijks.app/). Dit verkennen we verder.
+* **Financieel CV:** we bereidden de volgende sessie met het RVO-team voor Financieel CV voor.
+
+## Agenda
+
+💡 Wist je dat we (bijna) elke maandag samenwerken op het Beatrixpark in Den Haag? Wil je een keer aanhaken, dan ben je van harte welkom.
+
+**MOZa**
+
+* Logius PI planning - 10 & 11 juni
+* Regieteam - 11 juni (tijdens het Logius PI event)
+* MOZa Pulse - 18 juni
+* [Dag van de toekomst: ondernemer centraal](https://digilab.pleio.nl/groups/view/c182ef44-4cf1-4912-9afa-da3e8b509f32/evenementen-algemeen/events/view/969b45cd-7057-4251-a949-32214fe43663/dag-van-de-toekomst-ondernemer-centraal-en-regeldruk) - 18 juni - MOZa samen met [Digilab](https://digilab.overheid.nl/)
+* UX-onderzoeksdag - 22 juni
+* Stuurgroep - 16 juli
+
+**Evenementen**
+
+* [GovTech Day](https://www.digitaleoverheid.nl/evenementen/govtech-day/) - 11 juni
+* Dag van de Publieke Dienstverlening - 17 juni
+* [Overheid360°](https://www.digitaleoverheid.nl/evenementen/overheid360/) (Jaarbeurs Utrecht) - 17 juni
+* Developer.overheid.nl meetup - 17 juni
+* [Dag van de toekomst: ondernemer centraal](https://digilab.pleio.nl/groups/view/c182ef44-4cf1-4912-9afa-da3e8b509f32/evenementen-algemeen/events/view/969b45cd-7057-4251-a949-32214fe43663/dag-van-de-toekomst-ondernemer-centraal-en-regeldruk) - 18 juni - MOZa samen met [Digilab](https://digilab.overheid.nl/)
+* Werkgroep standaarden en architectuur (Obis) - 18 juni
+* [Bijeenkomst Netwerk van Datastelsels](https://realisatieibds.nl/groups/view/0056c9ef-5c2e-44f9-a998-e735f1e9ccaa/federatief-datastelsel/events/view/1a08b8c2-65d7-4da9-9114-36a8d51bbb6a/bijeenkomst-netwerk-van-datastelsels-23-juni) - 23 juni
+* [Samen versnellen met AI: de overheid van morgen begint nu](https://www.aanmelder.nl/174738) - 25 juni
+* [Dag van de Digitale Toegankelijkheid](https://dagvandedigitaletoegankelijkheid.nl/) - 28 juni
+* [Omnichannel: ID-wallets in overheidsdienstverlening](https://www.gebruikercentraal.nl/agenda/online-bijeenkomst-omnichannel-id-wallets-in-overheidsdienstverlening/) - 2 juli (online)
+* Common Ground Fieldlab - 14 & 15 september
+* Business Wallet B2G - 22 of 23 september
+* [Europe goes Once-Only: the Netherlands](https://www.digitaleoverheid.nl/evenementen/europe-goes-once-only-the-netherlands/) - 24 & 25 september
+* [IBDS-Stelseldag 2027](https://www.digitaleoverheid.nl/evenementen/ibds-stelseldag-2027/) - 3 februari 2027


### PR DESCRIPTION
MOZa Weekly van 10 juni 2026.

## Inhoud
- **Algemeen:** bijgewerkte onderwerppagina's, oproep Dag van de toekomst (18 juni), business wallets, werkgroep MijnZaken/MijnTaken, ODI, inwerken met AI.
- **Gebruikersonderzoek:** prototype aangescherpt, team gebruikersonderzoek en UX.
- **Profielservice:** onderwerppagina live, DPIA, richting productie.
- **Notificatiedienst:** beschrijving aangescherpt, voorbereiding Logius PI event.
- **Architectuur:** beschrijvende architectuur, kennismaking Digipoort.
- **Berichten / FBS:** pagina live, C4-model en visiedocument, techniek, webinar.
- **Authenticatie en autorisatie:** aftrap, klantreis met persona's.
- **Digitale Assistent:** pagina live, verhuizing naar eigen omgeving afgerond, AI-Verordening, Dag van de toekomst.
- **Regelhulpen / RegelRecht:** demo BZK, vervolg Regelhulpen, toekomstbeeld, Financieel CV.
- **Agenda** bijgewerkt (voorbije items verwijderd, nieuwe events toegevoegd).

Build en broken-links check (`just check`) zijn groen.