### PR TITLE
Voeg pagina Facilitaire diensten toe aan werkwijze

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -13,3 +13,4 @@ IgnoreURLs:
   - code.overheid.nl
   - realisatieibds.pleio.nl
   - docs.rijksapp.nl
+  - fmis.belastingdienst.nl

--- a/content/handboek/werkwijze/facilitaire-diensten.md
+++ b/content/handboek/werkwijze/facilitaire-diensten.md
@@ -1,0 +1,27 @@
+---
+title: Facilitaire diensten
+description: Hoe je een ruimte reserveert en waar je terecht kunt voor benodigdheden voor je sessie.
+weight: 30
+---
+
+Voor je sessies en bijeenkomsten regel je een aantal praktische zaken zelf. Hieronder lees je hoe je een ruimte reserveert en waar je terecht kunt voor de spullen die je nodig hebt.
+
+## Ruimte reserveren
+
+Ruimtes reserveer je op het facilitair portaal [CFD](https://fmis.belastingdienst.nl/). Reserveer op tijd, want ruimtes zijn niet altijd beschikbaar.
+
+- Via CFD boek je ruimtes van het Rijk (de zogeheten Rijkshubs). Deze zijn gratis te boeken.
+- Heb je een ruimte op een andere locatie nodig? Het secretariaat ([RIG@Rijksoverheid.nl](mailto:RIG@Rijksoverheid.nl)) kan betaald ruimtes reserveren op andere locaties.
+
+## Sessie benodigdheden
+
+Op elke verdieping van het Beatrixpark staat standaard een kast met materialen. Denk aan pennen, stiften, post-its en meer.
+
+Mis je iets? Neem contact op met Mahjouba Amtyi via [Mahjouba.Amtyi@rijksoverheid.nl](mailto:Mahjouba.Amtyi@rijksoverheid.nl).
+
+## Locatie
+
+Je vindt het Beatrixpark op:
+
+Wilhelmina van Pruisenweg 52  
+2595 AN Den Haag


### PR DESCRIPTION
## Wat

Nieuwe pagina **Facilitaire diensten** onder `handboek/werkwijze`, op hetzelfde niveau als `principes` en `rituelen`.

## Inhoud

- **Ruimte reserveren** — via het facilitair portaal CFD (gratis Rijkshubs); voor andere locaties kan het secretariaat (RIG) betaald reserveren.
- **Sessie benodigdheden** — kast met materialen op elke verdieping van het Beatrixpark; contact bij tekorten.
- **Locatie** — adres Beatrixpark, Den Haag.

## Plaatsing

`weight: 30` zodat de pagina als 3e kaart in het werkwijze-overzicht verschijnt (na principes `10` en rituelen `15`). Tone of voice afgestemd op de bestaande handboekpagina's.

## htmltest / link-check

De link-check faalde aanvankelijk met `Non-OK status: 400` op `https://fmis.belastingdienst.nl/`. Dat is het facilitair portaal **CFD**: een interne URL die alleen binnen het Belastingdienst-netwerk bereikbaar is en daarom niet vanaf de CI-runner gevalideerd kan worden. De link is correct. Daarom is `fmis.belastingdienst.nl` toegevoegd aan `IgnoreURLs` in `.htmltest.yml`, conform de bestaande interne links in die lijst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)