### PR TITLE
MOZa Weekly 17 juni 2026

### DIFF
--- a/content/weekly/2026/2026-06-17.md
+++ b/content/weekly/2026/2026-06-17.md
@@ -1,0 +1,85 @@
+---
+title: MOZa Weekly 17 juni 2026
+date: 2026-06-17
+---
+
+## Algemeen
+
+* **Dag van de toekomst: ondernemer centraal:** we hebben de laatste hand gelegd aan het programma en de workshops. Vanuit verschillende rollen beschrijven we levensgebeurtenissen waar een zakelijke gebruiker tegenaan loopt. Met elkaar gaan we aan de slag om dit als klantreis inclusief oplossingsrichtingen uit te werken. We organiseren deze dag samen met [Digilab](https://digilab.overheid.nl/).
+* **Logius PI event:** op 10 en 11 juni waren we bij het PI event van Logius. We maakten met alle betrokkenen een goede werkverdeling voor de notificatiedienst en de [profielservice](/onderwerpen/profielservice/). Ook ondertekenden we samen met Logius de MOZa-intentieverklaring, een mooie stap in onze samenwerking. Ook vanuit gebruikersonderzoek en UX stemden we het nodige af. Onder andere over de mogelijkheid om te wisselen tussen burger en onderneming.
+* **Juridisch meedenken:** hoe we het precies gaan doen, dat gaan we binnenkort bespreken. Maar we gaan kijken hoe we het juridische team al eerder aan kunnen haken in ons proces. Bijvoorbeeld door nieuwe prototypes die we hebben onderzocht, van tijd tot tijd met elkaar te bespreken.
+* **Veilig met AI:** als team schreven we onze ervaringen met AI op. Ook onderzochten we veiligere manieren om ontwikkelomgevingen te draaien waar we Claude Code met maximale kracht in kunnen zetten. Onze huidige aanpak is nog niet veilig genoeg, maar wordt wel steeds veiliger. Tot die tijd blijven er restricties in stand.
+* **Levensgebeurtenis "ondernemer in zwaar weer":** we spraken met de KVK over ondernemers in zwaar weer. De KVK werkt hier in opdracht van BZK aan. Binnenkort hebben we een vervolg en gaan we onderzoeken hoe we kunnen samenwerken.
+
+## Gebruikersonderzoek
+
+* **Prototype doorontwikkeld:** we werkten verder aan het [prototype](https://proef.moza.rijksapp.dev/moza/) voor de volgende ronde aan onderzoeken.
+* **Onderzoek bij de KVK:** ons geplande gebruikersonderzoek bij de KVK is verschoven naar volgende week. Samen met KVK Rotterdam gaan we onder andere het gesprek aan met ondernemers die zich net hebben ingeschreven. Een mooie manier om ondernemers te spreken over wat hun verwachtingen zijn en te toetsen of onze ideeën daarbij aansluiten.
+* **Inzicht in opvragen van gegevens:** in het prototype maakten we een begin met een functie waarmee gebruikers kunnen zien welke overheidspartijen welke gegevens hebben opgevraagd.
+* **Wisselen tussen burger en ondernemer:** op het Logius PI event spraken we over de samenhang met het burgerdomein en over hoe je soepel wisselt tussen het burger- en het zakelijke domein. Eerder gemaakte schetsen hiervoor nemen we mee in de komende onderzoeken.
+
+## Profielservice
+
+* **Richting productie:** we verwerkten de concept-acceptatievoorwaarden van Logius, patchten beveiligingsbevindingen, schreven beheerdocumentatie over database en deployment, en voegden een vaste codeerstandaard toe.
+* **Kwaliteit en privacy:** we voegden contracttesten toe, zodat we ons automatisch aan de gemaakte API-afspraken blijven houden. Ook kwam er een veld "te verwijderen op" in het datamodel. Daarnaast tonen foutmeldingen geen gevoelige informatie meer.
+* **Logboek Dataverwerkingen:** we werkten aan een stabiele release van het Logboek Dataverwerkingen.
+* **Code review met Claude Code:** we lieten een code review op de profielservice uitvoeren met Claude Code. De bevindingen analyseren we volgende week.
+* **Juridisch proces:** we bereiden het juridische proces voor dat we per 1 juli willen starten. Daarvoor zorgen we dat de DPIA en het beleidskompas op orde staan.
+
+## Notificatiedienst
+
+* **Start van het NMC:** we trapten het Notificatie Management Component (NMC) af. We bepaalden waar de documentatie staat, wat we eerst uitzoeken en wat juist (nog) niet. We brachten de eerste focus aan. Het doel: een notificatie laten lopen van de dienstverlener (OMC) naar de NMC, die deze met behulp van NotifyNL per e-mail verstuurt.
+* **NotifyNL:** we vatten de NotifyNL-specificatie samen, zodat duidelijk is hoe je deze kunt benaderen.
+* **Implementatieplan:** we vulden het implementatieplan verder in, met de bouwstenen en de verdeling van het werk.
+* **Samen met Logius:** we delen met Logius hetzelfde beeld van de notificatiedienst en hebben het werk voor de korte termijn verdeeld. Zo werken we samen aan het gestelde doel.
+
+## Architectuur
+
+* **Architectuursessies:** we bereiden sessies voor over de beschrijvende architectuur en het positioneringsdocument.
+* **Profielservice en andere bronnen:** we denken na over hoe de profielservice zich verhoudt tot het ontsluiten van andere bronnen, zoals de BRP en het handelsregister van de KVK. Voorlopig laten we dit via de profielservice lopen, maar we zijn er nog niet over uit.
+* **Bereikbaarheidsservice:** er kwam de vraag of de bereikbaarheidsservice onderdeel kan worden van de profielservice. Dit zoeken we uit.
+* **Mijn Taken:** we maakten een korte analyse van Mijn Taken, als vertrekpunt voor de verdere verkenning in het ondernemersdomein.
+
+## Berichten / FBS
+
+* **Bouwstenen afgerond:** we rondden de bouwstenen van de [proefopstelling](https://minbzk.github.io/moza-poc-fbs-berichtenbox/) van het [Federatief Berichtenstelsel](/onderwerpen/berichten-fbs/) af in een eindsprint. We verwerkten onder andere de overgang van de aanmeldservice naar de sessiecache en losten losse verbeterpunten op.
+* **C4-model uitgebreid:** we werkten het C4-model bij en breidden het uit met een berichtenmagazijn dat een organisatie zelf beheert.
+* **Demo in voorbereiding:** in de refinement bepaalden we welke use cases en flows we in de demo van de proefopstelling willen laten zien. Wordt vervolgd...
+* **Afstemming met BZK:** we stemmen met BZK af omdat FBS een onderwerp is waar al veel werk op is verzet. We willen daarop voortbouwen en er tegelijk met een frisse blik naar kunnen kijken.
+
+## Machtigen en mandaten
+
+* **Workshops in voorbereiding:** we maakten een eerste opzet voor workshops over authenticatie, autorisatie, machtigen en mandaten. Dit sluit aan op de actie uit het [plan voor fase 4](/documenten/rapportages/plan-moza-fase-4/). Hierin definiëren we onze persona's en schetsen we samen de klantreizen. De eerste sessie met het MOZa-team staat op dinsdag 30 juni. Een vervolg met een breder publiek plannen we nog. Als je interesse hebt, stuur dan een e-mail naar moza@minbzk.nl.
+
+## Design system
+
+* **Eén lijn in look-and-feel:** we bekijken welke omgevingen we nodig hebben voor demo's, proeven en ontwikkeling. We houden de look-and-feel en functionaliteit consistent.
+* **Experimenteren met NLDD:** we maakten een analyse van onze design-systemen: het NL Design System (NLDS), MOx en NLDD. We gaan experimenteren met NLDD en werken parallel verder met (RHC-)NLDS, zodat we goed aansluiten op de ontwikkelstraat van Logius.
+
+## Agenda
+
+💡 Wist je dat we (bijna) elke maandag samenwerken op het Beatrixpark in Den Haag? Wil je een keer aanhaken, dan ben je van harte welkom.
+
+**MOZa**
+
+* MOZa Pulse - 18 juni
+* Werkgroep standaarden en architectuur (Obis / MOZa) - 18 juni
+* [Dag van de toekomst: ondernemer centraal](https://digilab.pleio.nl/groups/view/c182ef44-4cf1-4912-9afa-da3e8b509f32/evenementen-algemeen/events/view/969b45cd-7057-4251-a949-32214fe43663/dag-van-de-toekomst-ondernemer-centraal-en-regeldruk) - 18 juni - MOZa samen met [Digilab](https://digilab.overheid.nl/)
+* UX-onderzoeksdag - 22 juni
+* Verdieping met de Belastingdienst over notificeren en contactherstel - 24 juni
+* Kennismaking levensgebeurtenissen KVK (Utrecht) - 25 juni
+* Werksessie machtigen en mandaten - 30 juni
+* Regieteam - 2 juli
+* Stuurgroep - 16 juli
+
+**Evenementen**
+
+* [Dag van de toekomst: ondernemer centraal](https://digilab.pleio.nl/groups/view/c182ef44-4cf1-4912-9afa-da3e8b509f32/evenementen-algemeen/events/view/969b45cd-7057-4251-a949-32214fe43663/dag-van-de-toekomst-ondernemer-centraal-en-regeldruk) - 18 juni - MOZa samen met [Digilab](https://digilab.overheid.nl/)
+* [Bijeenkomst Netwerk van Datastelsels](https://realisatieibds.nl/groups/view/0056c9ef-5c2e-44f9-a998-e735f1e9ccaa/federatief-datastelsel/events/view/1a08b8c2-65d7-4da9-9114-36a8d51bbb6a/bijeenkomst-netwerk-van-datastelsels-23-juni) - 23 juni
+* [Samen versnellen met AI: de overheid van morgen begint nu](https://www.aanmelder.nl/174738) - 25 juni
+* [Dag van de Digitale Toegankelijkheid](https://dagvandedigitaletoegankelijkheid.nl/) - 28 juni
+* [Omnichannel: ID-wallets in overheidsdienstverlening](https://www.gebruikercentraal.nl/agenda/online-bijeenkomst-omnichannel-id-wallets-in-overheidsdienstverlening/) - 2 juli (online)
+* Common Ground Fieldlab - 14 & 15 september
+* Business Wallet B2G - 22 of 23 september
+* [Europe goes Once-Only: the Netherlands](https://www.digitaleoverheid.nl/evenementen/europe-goes-once-only-the-netherlands/) - 24 & 25 september
+* [IBDS-Stelseldag 2027](https://www.digitaleoverheid.nl/evenementen/ibds-stelseldag-2027/) - 3 februari 2027


### PR DESCRIPTION
MOZa Weekly van 17 juni 2026.

Hoogtepunten: Logius PI event (werkverdeling + intentieverklaring), profielservice richting productie, start NMC, FBS-bouwstenen afgerond, aftrap machtigen en mandaten, en samenwerking met KVK rond "ondernemer in zwaar weer". Agenda bijgewerkt.