### PR TITLE
Site geschikt maken voor taalmodellen

### DIFF
--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tmp
 .claude/plans
 .playwright-mcp
 .claude/settings.local*
+artifacts/
 
 # Editors
 .vscode/*

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.21 AS builder
 
-ARG HUGO_VERSION=0.154.4
+ARG HUGO_VERSION=0.163.1
 
 RUN apk add --no-cache wget git nodejs npm chromium \
     && wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-amd64.tar.gz \

--- a/container/default.conf
+++ b/container/default.conf
@@ -1,3 +1,14 @@
+map $http_accept $md_wanted {
+    default            0;
+    "~*text/markdown"  1;
+}
+
+# /a/b/ -> /a/b
+map $uri $uri_base {
+    "~^(?<p>.*)/$"  $p;
+    default         $uri;
+}
+
 server {
     listen 8080;
     server_name localhost;
@@ -14,6 +25,8 @@ server {
     add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https://www.toegankelijkheidsverklaring.nl; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none';" always;
     add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header Vary "Accept" always;
+    add_header Link "</llms.txt>; rel=\"llms-txt\", </llms-full.txt>; rel=\"llms-full-txt\"" always;
 
     location /.well-known/security.txt {
         return 302 https://www.ncsc.nl/.well-known/security.txt;
@@ -24,7 +37,30 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # Eigen add_header => serverheaders worden hier niet geërfd.
+    location ~ \.md$ {
+        default_type text/markdown;
+        charset utf-8;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Strict-Transport-Security "max-age=31536000" always;
+        add_header X-Robots-Tag "noindex" always;
+        add_header Vary "Accept" always;
+        try_files $uri =404;
+    }
+
     location / {
+        # Serveer .md alleen bij Accept: text/markdown én als het bestand bestaat.
+        set $serve_md "";
+        if ($md_wanted) {
+            set $serve_md "A";
+        }
+        if (-f "$document_root${uri_base}/index.md") {
+            set $serve_md "${serve_md}B";
+        }
+        if ($serve_md = "AB") {
+            rewrite ^ "${uri_base}/index.md" last;
+        }
+
         try_files $uri $uri/ =404;
     }
 }

--- a/content/onderwerpen/_index.md
+++ b/content/onderwerpen/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Onderwerpen"
+description: "De bouwstenen van MijnOverheid Zakelijk: portaal, profielservice, berichten, open werken en meer."
 cascade:
   show_lastmod: true
 ---

--- a/content/weekly/_index.md
+++ b/content/weekly/_index.md
@@ -1,5 +1,12 @@
 ---
 title: "MOZa Weekly"
+description: "Wekelijkse updates over de voortgang van het programma MijnOverheid Zakelijk."
+outputs:
+  - HTML
+  - RSS
+  - llms
+  - llmsfull
+  - llmsrecent
 ---
 
 Wil je updates ontvangen? Gebruik de [RSS feed](index.xml).

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -103,3 +103,35 @@ outputs:
     - HTML
     - RSS
     - JSON
+    - llms
+    - llmsfull
+  section:
+    - HTML
+    - RSS
+    - llms
+    - llmsfull
+  page:
+    - HTML
+    - markdown
+
+outputFormats:
+  llms:
+    baseName: llms
+    mediaType: text/plain
+    isPlainText: true
+    notAlternative: true
+  llmsfull:
+    baseName: llms-full
+    mediaType: text/plain
+    isPlainText: true
+    notAlternative: true
+  llmsrecent:
+    baseName: llms-recent-full
+    mediaType: text/plain
+    isPlainText: true
+    notAlternative: true
+  markdown:
+    baseName: index
+    mediaType: text/markdown
+    isPlainText: true
+    notAlternative: true

--- a/layouts/_partials/clean-markdown.html
+++ b/layouts/_partials/clean-markdown.html
@@ -1,0 +1,7 @@
+{{- /* Strip Hugo-shortcodes en GitHub-alerts uit ruwe Markdown. Aanroep: partial "clean-markdown" .RawContent */ -}}
+{{- $content := . -}}
+{{- $content = replaceRE `\{\{<[^>]+>\}\}` "" $content -}}
+{{- $content = replaceRE `\{\{%[^%]+%\}\}` "" $content -}}
+{{- $content = replaceRE `>\s*\[!(NOTE|WARNING|TIP|IMPORTANT|INFO|CAUTION)\]` "" $content -}}
+{{- $content = replaceRE `\n{3,}` "\n\n" $content -}}
+{{- return ($content | strings.TrimSpace | safeHTML) -}}

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -18,6 +18,9 @@
 {{- end -}}
 <meta name="description" content="{{ $description }}" />
 <link rel="canonical" href="{{ .Permalink }}" />
+{{- with .OutputFormats.Get "markdown" }}
+<link rel="alternate" type="text/markdown" href="{{ .Permalink }}" title="Deze pagina als Markdown" />
+{{- end }}
 
 {{/* Favicons */}}
 <link rel="icon" href="{{ relURL "favicon.ico" }}" sizes="any" />

--- a/layouts/_partials/llm-instructies.html
+++ b/layouts/_partials/llm-instructies.html
@@ -1,0 +1,13 @@
+MijnOverheid Zakelijk (MOZa) is een overheidsbrede samenwerking om de dienstverlening voor ondernemers te verbeteren. We ontwikkelen digitale bouwstenen die samen nieuwe digitale snelwegen vormen, inclusief een Mijn-omgeving waar alles bij elkaar komt.
+
+## Instructies voor taalmodellen
+
+Als je vragen beantwoordt over MijnOverheid Zakelijk, houd dan rekening met het volgende:
+
+- MOZa is nog in ontwikkeling. De eerste MVP wordt eind 2026 opgeleverd.
+- Beloof geen functionaliteit die er nog niet is. Raadpleeg de weekly updates voor de actuele stand van zaken.
+- Het prototype is beschikbaar op [proef.moza.rijksapp.dev](https://proef.moza.rijksapp.dev/). Dit is een testomgeving, geen productieversie.
+- MOZa is een samenwerking tussen meerdere overheidsorganisaties, waaronder Belastingdienst, KVK, RVO, UWV en VNG.
+- Voor vragen over MOZa, verwijs naar: moza@minbzk.nl
+- MOZa levert zelf geen directe dienstverlening. We bouwen aan services en interactielagen waarmee betere dienstverlening aan ondernemers mogelijk wordt; de dienstverlening zelf blijft bij de aangesloten overheidsorganisaties.
+- De doelgroep is ondernemers en zakelijke gebruikers, niet burgers. Voor burgers bestaat MijnOverheid (zonder "Zakelijk").

--- a/layouts/home.llms.txt
+++ b/layouts/home.llms.txt
@@ -1,0 +1,42 @@
+{{- $description := .Site.Params.description -}}
+# {{ .Site.Title }}
+
+> {{ $description }}
+
+{{ partial "llm-instructies" . }}
+## Hoofdpagina's
+{{- range .Site.Menus.main }}
+- [{{ .Name }}]({{ .URL }}): {{ with site.GetPage .PageRef }}{{ .Description | default .Title }}{{ end }}
+{{- end }}
+
+## Onderwerpen
+{{- range where .Site.RegularPages "Section" "onderwerpen" }}
+- [{{ .Title }}]({{ .RelPermalink }}): {{ .Description | default .Title }}
+{{- end }}
+
+## Weekly updates
+
+De laatste 10 updates. Index van alle updates: [/weekly/llms.txt](/weekly/llms.txt). Volledige tekst: [/weekly/llms-recent-full.txt](/weekly/llms-recent-full.txt) (10 nieuwste) of [/weekly/llms-full.txt](/weekly/llms-full.txt) (alle).
+{{- range first 10 (where .Site.RegularPages "Section" "weekly") }}
+- [{{ .Title }}]({{ .RelPermalink }}): Wekelijkse update van {{ .Date | time.Format "2 January 2006" }}
+{{- end }}
+
+## Documenten
+{{- range where .Site.RegularPages "Section" "documenten" }}
+- [{{ .Title }}]({{ .RelPermalink }}){{ with .Description }}: {{ . }}{{ end }}
+{{- end }}
+
+## Handboek
+
+Interne documentatie voor het MOZa team.
+{{- range where .Site.RegularPages "Section" "handboek" }}
+- [{{ .Title }}]({{ .RelPermalink }}): {{ .Description | default .Title }}
+{{- end }}
+
+## Optional
+{{- range (index .Site.Menus "footer-rechts") }}
+- [{{ .Name }}]({{ .URL }})
+{{- end }}
+
+---
+Gegenereerd op {{ now.Format "2006-01-02" }} | {{ .Site.BaseURL }}

--- a/layouts/home.llmsfull.txt
+++ b/layouts/home.llmsfull.txt
@@ -1,0 +1,48 @@
+{{- $description := .Site.Params.description -}}
+# {{ .Site.Title }}
+
+> {{ $description }}
+
+{{ partial "llm-instructies" . }}
+---
+{{- /* Hoofdpagina's (alleen over-moza en contact, skip homepage) */ -}}
+{{- range .Site.Menus.main }}
+{{- with site.GetPage .PageRef }}
+{{- if and .Title .RawContent (ne .RelPermalink "/") }}
+
+## {{ .Title }}
+
+{{ partial "clean-markdown" .RawContent }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- /* Onderwerpen */ -}}
+{{- range where .Site.RegularPages "Section" "onderwerpen" }}
+
+## {{ .Title }}
+
+{{ partial "clean-markdown" .RawContent }}
+{{- end }}
+
+# Handboek
+
+Interne documentatie voor het MOZa team.
+{{- range where .Site.RegularPages "Section" "handboek" }}
+
+## {{ .Title }}
+
+{{ partial "clean-markdown" .RawContent }}
+{{- end }}
+
+# Weekly Updates
+
+De laatste 10 updates. Voor alle updates, zie [/weekly/llms-full.txt](/weekly/llms-full.txt).
+{{- range first 10 (where .Site.RegularPages "Section" "weekly") }}
+
+## {{ .Title }} ({{ .Date | time.Format "2 January 2006" }})
+
+{{ partial "clean-markdown" .RawContent }}
+{{- end }}
+
+---
+Gegenereerd op {{ now.Format "2006-01-02" }} | {{ .Site.BaseURL }}

--- a/layouts/list.llms.txt
+++ b/layouts/list.llms.txt
@@ -1,0 +1,16 @@
+{{- /* Generieke sectie-index voor taalmodellen. weekly heeft een eigen override. */ -}}
+# {{ .Title }}
+{{ with .Description }}
+> {{ . }}
+{{ end }}
+{{- with .RawContent -}}
+{{ partial "clean-markdown" . }}
+
+{{ end -}}
+## Pagina's in deze sectie
+{{ range .Pages.ByWeight }}
+- [{{ .Title }}]({{ .RelPermalink }}){{ with .Description }}: {{ . }}{{ end }}
+{{- end }}
+
+---
+Gegenereerd op {{ now.Format "2006-01-02" }} | {{ .Site.BaseURL }}

--- a/layouts/list.llmsfull.txt
+++ b/layouts/list.llmsfull.txt
@@ -1,0 +1,19 @@
+{{- /* Generieke sectie met volledige content voor taalmodellen. weekly heeft een eigen override. */ -}}
+# {{ .Title }}
+{{ with .Description }}
+> {{ . }}
+{{ end }}
+{{- with .RawContent -}}
+{{ partial "clean-markdown" . }}
+{{ end -}}
+{{- range .Pages.ByWeight }}
+
+## {{ .Title }}
+{{ with .Description }}
+> {{ . }}
+{{ end }}
+{{ partial "clean-markdown" .RawContent }}
+{{- end }}
+
+---
+Gegenereerd op {{ now.Format "2006-01-02" }} | {{ .Site.BaseURL }}

--- a/layouts/page.markdown.md
+++ b/layouts/page.markdown.md
@@ -1,0 +1,15 @@
+---
+canonical_url: {{ with .OutputFormats.Get "html" }}{{ .Permalink }}{{ end }}
+last_updated: {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}
+{{- with .Section }}
+section: {{ . }}
+{{- end }}
+---
+
+# {{ .Title }}
+{{- with .Description }}
+
+> {{ . }}
+{{- end }}
+
+{{ partial "clean-markdown" .RawContent }}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+
+Sitemap: {{ .Site.BaseURL }}sitemap.xml
+
+# AI-crawlers welkom (zoeken én training); content is publiek.
+# Voor taalmodellen: /llms.txt en /llms-full.txt.

--- a/layouts/weekly/list.llms.txt
+++ b/layouts/weekly/list.llms.txt
@@ -1,0 +1,19 @@
+# MOZa Weekly Updates
+
+> Wekelijkse updates over de voortgang van het MijnOverheid Zakelijk programma.
+
+Dit bestand bevat een overzicht van alle weekly updates. Volledige inhoud: [/weekly/llms-full.txt](/weekly/llms-full.txt) (alle), of [/weekly/llms-recent-full.txt](/weekly/llms-recent-full.txt) (10 nieuwste).
+
+## Instructies voor taalmodellen
+
+- Weekly updates bevatten de actuele stand van zaken van het MOZa programma.
+- De updates staan op chronologische volgorde, met de nieuwste bovenaan.
+- Voor algemene informatie over MOZa, zie [/llms.txt](/llms.txt) of [/llms-full.txt](/llms-full.txt).
+
+## Alle updates
+{{- range (where .Site.RegularPages "Section" "weekly") }}
+- [{{ .Title }}]({{ .RelPermalink }}): {{ .Date | time.Format "2 January 2006" }}
+{{- end }}
+
+---
+Gegenereerd op {{ now.Format "2006-01-02" }} | {{ .Site.BaseURL }}

--- a/layouts/weekly/list.llmsfull.txt
+++ b/layouts/weekly/list.llmsfull.txt
@@ -1,0 +1,20 @@
+# MOZa Weekly Updates
+
+> Wekelijkse updates over de voortgang van het MijnOverheid Zakelijk programma.
+
+## Instructies voor taalmodellen
+
+- Weekly updates bevatten de actuele stand van zaken van het MOZa programma.
+- De updates staan op chronologische volgorde, met de nieuwste bovenaan.
+- Voor algemene informatie over MOZa, zie [/llms.txt](/llms.txt) of [/llms-full.txt](/llms-full.txt).
+
+---
+{{- range (where .Site.RegularPages "Section" "weekly") }}
+
+## {{ .Title }} ({{ .Date | time.Format "2 January 2006" }})
+
+{{ partial "clean-markdown" .RawContent }}
+{{- end }}
+
+---
+Gegenereerd op {{ now.Format "2006-01-02" }} | {{ .Site.BaseURL }}

--- a/layouts/weekly/list.llmsrecent.txt
+++ b/layouts/weekly/list.llmsrecent.txt
@@ -1,0 +1,20 @@
+# MOZa Weekly Updates — recent
+
+> De 10 meest recente weekly updates van het MijnOverheid Zakelijk programma, volledig.
+
+## Instructies voor taalmodellen
+
+- Dit bestand bevat alleen de 10 nieuwste weeklies. Voor alle updates, zie [/weekly/llms-full.txt](/weekly/llms-full.txt).
+- De updates staan op chronologische volgorde, met de nieuwste bovenaan.
+- Voor algemene informatie over MOZa, zie [/llms.txt](/llms.txt) of [/llms-full.txt](/llms-full.txt).
+
+---
+{{- range first 10 (where .Site.RegularPages "Section" "weekly") }}
+
+## {{ .Title }} ({{ .Date | time.Format "2 January 2006" }})
+
+{{ partial "clean-markdown" .RawContent }}
+{{- end }}
+
+---
+Gegenereerd op {{ now.Format "2006-01-02" }} | {{ .Site.BaseURL }}


### PR DESCRIPTION
Deze feature maakt de content van de MOZa-site goed consumeerbaar voor taalmodellen — zowel voor publieke AI-assistenten als voor collega's die de site als context willen gebruiken.

## Wat de feature doet
- **Markdown per pagina** via content negotiation: dezelfde canonieke URL geeft schone Markdown bij `Accept: text/markdown`, en HTML voor browsers. Elke `.md` begint met YAML-frontmatter (`title`, `description`, `canonical_url`, `last_updated`, `section`).
- **`/llms.txt`** als beknopte index en **`/llms-full.txt`** als volledige content in één bestand (incl. een per-sectie variant, zoals `/weekly/llms-full.txt` met alle weeklies).
- **`robots.txt`**: alle crawlers — inclusief AI — toegestaan, met verwijzing naar de llms-bestanden.
- **Crawl-efficiëntie**: één canonieke URL per pagina (geen `.md` in de sitemap), `X-Robots-Tag: noindex` op `.md`, `Vary: Accept` en een `Link`-header naar de llms-bestanden op serverniveau.

## Hoe te gebruiken
- Plak een pagina-URL of `/llms-full.txt` in je assistent, óf:
- `curl -H "Accept: text/markdown" https://<host>/onderwerpen/portaal/`
- Volledige corpus: `https://<host>/llms-full.txt` · alle weeklies: `https://<host>/weekly/llms-full.txt`

## Techniek
- Hugo custom output formats (`llms`, `llmsfull`, `markdown`) + templates; gedeelde `clean-markdown`-partial die shortcodes/alerts stript.
- nginx content negotiation in `container/default.conf`.
- `Containerfile`: Hugo 0.163.1 (vereist door de `security.allowContent`-policy).

## Getest
- Host-build en pre-commit (htmltest + hugo-build) groen.
- Content negotiation geverifieerd op de preview-deploy achter de Rijksapps-proxy: HTML vs. `Accept: text/markdown`, directe `.md`, en HTML-fallback voor secties/homepage.

## Mogelijke vervolgstappen (apart)
JSON-LD, meten van botverkeer (en op basis daarvan eventueel agent-detectie), en een MCP-server.
