### PR TITLE
MOZa Weekly 24 juni 2026

### DIFF
--- a/content/weekly/2025/2025-11-10.md
+++ b/content/weekly/2025/2025-11-10.md
@@ -42,7 +42,7 @@ date: 2025-11-10
 
 Wist je dat we (bijna) elke maandag samenwerken op Beatrixpark in Den Haag? Wil je een keer aanhaken, dan ben je van harte welkom.
 
-- **[KVK Ondernemersdagen](https://www.kvk.nl/evenementen/kvk-ondernemersdagen-2025/)**: 14 & 15 november
+- **KVK Ondernemersdagen**: 14 & 15 november
 - **MOZa Pulse**: 18 november
 - **Teamdag**: 18 november
 - **Stuurgroep**: 21 november

--- a/content/weekly/2026/2026-06-24.md
+++ b/content/weekly/2026/2026-06-24.md
@@ -1,0 +1,91 @@
+---
+title: MOZa Weekly 24 juni 2026
+date: 2026-06-24
+---
+
+## Algemeen
+
+* **MOZa Pulse:** tijdens deze editie gaven we een update over de notificatiedienst en lichtten we die toe aan de hand van de architectuurplaten. Daarnaast vertelden we over guerrillaonderzoek, deelden we onze eerste inzichten en lieten we de proefopstelling zien die we daarvoor gebruikten.
+* **Terugblik Dag van de toekomst:** op 18 juni organiseerden we samen met [Digilab](https://digilab.overheid.nl/) de [Dag van de toekomst: ondernemer centraal](https://digilab.pleio.nl/groups/view/c182ef44-4cf1-4912-9afa-da3e8b509f32/evenementen-algemeen/events/view/969b45cd-7057-4251-a949-32214fe43663/dag-van-de-toekomst-ondernemer-centraal-en-regeldruk). Een geslaagde dag met veel nieuwe verbindingen en het opdoen van nieuwe inzichten tijdens de workshops.
+* **Ervaringen met Claude Code gedeeld:** we gaven een presentatie over onze ervaringen en geleerde lessen met Claude Code van de afgelopen maanden.
+* **Site geschikt voor taalmodellen:** wie informatie bij publieke sites opvraagt, gebruikt daar steeds vaker AI-tools voor. Daarom maakten we de MOZa-site hier geschikt voor. De site serveert nu ook markdown en een `llms.txt`. Herkennen we een AI-agent, dan krijg je automatisch content die geoptimaliseerd is voor deze AI-agents. Dat scheelt weer wat tokens.
+* **Programma-architect:** we voerden gesprekken voor een programma-architect voor Obis en MOZa. En met goed nieuws: per 1 juli start dit nieuwe teamlid.
+* **Eerste PO-overleg:** het MOZa-team groeit en ondertussen werken er drie teams aan de diverse onderwerpen. De PO's hadden een eerste gezamenlijk overleg om afhankelijkheden en behoeftes te bespreken. Een mooie manier om te kijken hoe ze elkaar kunnen helpen richting de komende sprints.
+
+## Gebruikersonderzoek
+
+* **Ondernemersonderzoek bij de KVK:** onze gebruikersonderzoekers zaten een dag bij de KVK. Ze spraken ondernemers die daarvoor openstonden. Daarbij keken we ook mee hoe ondernemers zich inschreven bij de KVK. Zo kregen we mooie inzichten in hoe deze nieuwe ondernemers tegen informatie van de overheid aankijken.
+* **Inzicht in opvragen van gegevens:** we rondden in de [proefopstelling](https://proef.moza.rijksapp.dev/moza/) de functie af waarmee we vastleggen welke partijen contactgegevens opvragen. Eerder maakten we hier een begin mee. Zo werken we toe naar inzicht voor gebruikers in welke partijen hun gegevens hebben opgevraagd.
+
+## Profielservice
+
+* **Richting productie:** we werken verder aan de profielservice volgens de acceptatievoorwaarden van Logius. We onderzochten tooling die Logius gebruikt en voerden die in. Zo bewaken we nu automatisch de codekwaliteit, waarmee we aansluiten bij de codeerstandaard die Logius hanteert.
+* **DPIA:** we vulden de DPIA verder aan, vooral het deel over de gegevens. Ook stemden we af met het juridische team over de openstaande vragen.
+* **Veilige foutmeldingen:** we voegden toe dat de profielservice bij een foutieve aanvraag (404) een nette foutmelding teruggeeft. Die toont geen gevoelige informatie meer. Dit stond eerder in review en is nu afgerond.
+* **Code review met Claude Code:** we analyseerden de bevindingen uit de code review op de [profielservice](/onderwerpen/profielservice/) en maakten hier issues van op de backlog. Deze punten werken we de komende tijd verder weg.
+* **Logboek Dataverwerkingen:** Logius bracht versie 1.0.0 van de standaard voor het Logboek Dataverwerkingen uit. We bekeken wat dit voor ons softwarepakket betekent en maakten een begin met de aanpassingen.
+
+## Notificatiedienst
+
+* **De rol van het NMC:** het Notificatie Management Component (NMC) is de regisseur van het notificeren. Zelf verstuurt het geen berichten. Een dienstverlener biedt een notificatie aan via het decentrale Output Management Component (OMC). Het NMC pikt die op en regisseert het hele proces: het verzamelt de benodigde gegevens en bepaalt hoe en waar de notificatie heen moet. Het versturen geeft het door aan NotifyNL, dat de notificatie daadwerkelijk bezorgt. Daarna houdt het NMC bij wat er gebeurt en legt dit vast. Ook contactherstel valt onder zijn regie.
+* **Opzet NMC:** we werkten aan de eerste opzet van het NMC. De architectuur van de oplossing bespraken we met elkaar en die krijgt steeds meer vorm. De eerste opzet is bijna klaar om te testen in de samenhang met NotifyNL.
+* **Beslissingen vastgelegd:** we legden beslissingen over het NMC vast, zodat we ze kunnen delen en beoordelen. Ook werkten we de documentatie en het C4-model op componentniveau bij.
+* **Contactherstel:** we werkten de sequence-diagrammen bij en voegden onder andere contactherstel toe als los element.
+* **Samenwerking met Logius:** met twee teams werken we aan componenten van de notificatiedienst. Met elkaar bekijken we hoe we dit vorm kunnen geven. Zo starten we 1 juli een samenwerkdag voor deze teams.
+
+## Architectuur
+
+* **Beschrijvende architectuur:** we werkten verder aan het positioneringsdocument over de interactiedienstverlening van MijnOverheid.
+* **Werkgroepen met Obis en update Bureau Architectuur:** afgelopen week hielden we de werkgroep Profiel & Notificeren en de werkgroep Architectuur & Standaarden. Deze gesprekken brengen ons op één lijn met de verschillende organisaties. Ook zien we beter waar we nog anders over denken. De opgedane inzichten en de voorgestelde architectuur bespraken we ook met Bureau Architectuur van BZK.
+* **Eisen aan het autorisatiemodel:** de inzichten over het autorisatiemodel zijn breder bruikbaar. Ze sluiten aan op de update van de domeinarchitectuur voor het toegangsverleningsstelsel (TVS). Dit pakken we verder op met de collega's die hieraan werken.
+* **Stakeholders meenemen:** we merken opnieuw hoe belangrijk het is om alle stakeholders mee te blijven nemen. Op sommige vlakken zijn we al verder dan betrokkenen weten. In de ene sessie dachten deelnemers opbouwend mee, in de andere stelden ze juist veel vragen bij de keuzes die we maakten. Daar geven we de komende tijd aandacht aan.
+
+## Berichten / FBS
+
+* **Proefopstelling op ZAD:** de [proefopstelling van het Federatief Berichtenstelsel](https://minbzk.github.io/moza-poc-fbs-berichtenbox/) draait nu op het [ZAD-cluster](https://zad.rijksapp.nl/) bij ODC-Noord. De omgevingen voor de uitvraag- en magazijnservices zijn nu zichtbaar via hun eigen Swagger UI's. Je kunt meekijken bij de [uitvraagservice](https://uitvraag-pr-104-mpfb-8wh.rig.prd1.gn2.quattro.rijksapps.nl/q/swagger-ui) en de [magazijnservice](https://magazijna-pr-104-mpfm-w3h.rig.prd1.gn2.quattro.rijksapps.nl/q/swagger-ui). Dit zijn tijdelijke preview-omgevingen, dus de links werken mogelijk niet meer als je dit later leest.
+* **Stabielere tests:** we losten een bron van wisselvallige tests op, zodat onze testresultaten betrouwbaarder zijn.
+
+## Machtigen en mandaten
+
+* **Persona's en klantreizen:** we werkten verder aan de persona's en klantreizen voor authenticatie, autorisatie, machtigen en mandaten. Zo gaan we goed voorbereid de werksessie van 30 juni in. Dit sluit aan op de actie uit het [plan voor fase 4](/documenten/rapportages/plan-moza-fase-4/).
+
+## Design system
+
+* **Experimenteren met NLDD:** we onderzochten onder andere NLDD in combinatie met server-side rendering.
+* **Componenten NLDS:** met (RHC-)NLDS kijken we verder naar de inzet van componenten voor het ondernemersportaal.
+* **Persona's en klantreis visueel:** we maakten met NLDD een eerste versie van persona-cards en een tijdlijn voor de klantreis. Deze gebruikten we in de workshop op de Dag van de toekomst.
+
+## Digitale Assistent
+
+* **Demo verbeterd:** we verbeterden de demo van de [Digitale Assistent](/onderwerpen/digitale-assistent/) met een notificatie, een formulier in de chat en functionaliteit die een zaakdossier aanmaakt zodra je een rapportage instuurt.
+* **Op weg naar MVP:** we hebben een lijst opgesteld met to-do's voor de MVP en de bèta.
+
+## Regelhulpen, RegelRecht en machine-uitvoerbare wetgeving
+
+* **Validatie Financieel CV:** we draaiden de nieuwe validatieskills van [RegelRecht](https://regelrecht.rijks.app/) over de branch voor Financieel CV. Hieruit kwamen verbeteringen en materiaal voor de workshop voort.
+* **Documentatie:** we beschreven de scope en de samenhang met de stelsels.
+
+## Agenda
+
+💡 Wist je dat we (bijna) elke maandag samenwerken op het Beatrixpark in Den Haag? Wil je een keer aanhaken, dan ben je van harte welkom.
+
+**MOZa**
+
+* Kennismaking levensgebeurtenissen KVK (Utrecht) - 25 juni
+* Werksessie machtigen en mandaten - 30 juni
+* Teamoverleg - 1 juli
+* Samenwerkdag met Logius - 1 juli
+* Regieteam - 2 juli
+* MOZa Pulse - 16 juli
+* Stuurgroep - 16 juli
+
+**Evenementen**
+
+* [Samen versnellen met AI: de overheid van morgen begint nu](https://www.aanmelder.nl/174738) - 25 juni
+* [Dag van de Digitale Toegankelijkheid](https://dagvandedigitaletoegankelijkheid.nl/) - 28 juni
+* [Omnichannel: ID-wallets in overheidsdienstverlening](https://www.gebruikercentraal.nl/agenda/online-bijeenkomst-omnichannel-id-wallets-in-overheidsdienstverlening/) - 2 juli
+* [Hackathon Transparantie App](https://www.geonovum.nl/agenda/hackathon-transparantie-app-9-en-10-juli) - 9 & 10 juli
+* Common Ground Fieldlab - 14 & 15 september
+* Business Wallet B2G - 22 of 23 september
+* [Europe goes Once-Only: the Netherlands](https://www.digitaleoverheid.nl/evenementen/europe-goes-once-only-the-netherlands/) - 24 & 25 september
+* [IBDS-Stelseldag 2027](https://www.digitaleoverheid.nl/evenementen/ibds-stelseldag-2027/) - 3 februari 2027


### PR DESCRIPTION
## MOZa Weekly 24 juni 2026

Nieuwe editie van de MOZa Weekly.

### Inhoud
- **Algemeen:** terugblik Dag van de toekomst, MOZa Pulse, ervaringen met Claude Code, site geschikt voor taalmodellen, programma-architect, eerste PO-overleg.
- **Gebruikersonderzoek:** ondernemersonderzoek bij de KVK, inzicht in opvragen van gegevens.
- **Profielservice:** richting productie, DPIA, veilige foutmeldingen, code review, Logboek Dataverwerkingen 1.0.0.
- **Notificatiedienst:** het NMC als regisseur van het notificeren, opzet NMC, contactherstel, samenwerking met Logius.
- **Architectuur, Berichten/FBS, Machtigen en mandaten, Design system, Digitale Assistent, RegelRecht.**
- **Agenda** bijgewerkt (MOZa + Evenementen).

### Daarnaast
- Dode KVK-link verwijderd uit de weekly van 10 november 2025 (event voorbij, pagina geeft 404).

Build, tests en broken-link check (`just check` / `just test`) zijn groen.