### PR TITLE
Experiment: rustige witte menubalk

### DIFF
--- a/assets/css/components/header.css
+++ b/assets/css/components/header.css
@@ -68,13 +68,13 @@ header {
     max-width: var(--content-max-width);
     margin: 0 auto;
     padding: 0 1rem;
-    background-color: var(--color-rijks-blauw);
-    box-shadow: 0 0 0 100vmax var(--color-rijks-blauw);
+    background-color: var(--color-navbar-bg);
+    box-shadow: 0 0 0 100vmax var(--color-navbar-bg);
     clip-path: inset(0 -100vmax);
-    color: var(--color-text-inverse);
+    color: var(--color-navbar-text);
 
     a {
-      color: var(--color-text-inverse);
+      color: var(--color-navbar-text);
       text-decoration: none;
 
       &:hover {
@@ -82,7 +82,7 @@ header {
       }
 
       &:focus-visible {
-        outline: 2px solid var(--color-text-inverse);
+        outline: 2px solid var(--color-navbar-focus);
         outline-offset: 2px;
       }
 
@@ -154,57 +154,44 @@ header {
 
       @media (min-width: 768px) {
         display: flex;
+        align-items: center;
+        gap: 0.625rem;
       }
 
-      li {
-        margin-left: 0.75rem;
-      }
 
       .theme-toggle,
       .search-trigger {
-        height: 32px;
         background: transparent;
-        border: 1px solid rgba(255, 255, 255, 0.3);
-        color: var(--color-text-inverse);
-        padding: 0 8px;
+        border: none;
+        border-radius: 0;
+        color: var(--color-navbar-text);
         display: flex;
         align-items: center;
-        justify-content: center;
+
+        &:hover {
+          background-color: var(--color-navbar-control-hover-bg);
+        }
+
+        &:focus-visible {
+          outline: 2px solid var(--color-navbar-focus);
+          outline-offset: 2px;
+        }
+      }
+
+      .search-trigger {
+        gap: 0.375rem;
+        padding: 0.125rem 0.5rem;
+        font-size: 1.25rem;
       }
 
       .theme-toggle {
         width: 32px;
+        height: 32px;
         padding: 0;
-
-        &:hover {
-          background-color: rgba(255, 255, 255, 0.1);
-          border-color: rgba(255, 255, 255, 0.5);
-        }
-
-        &:focus-visible {
-          outline: 2px solid var(--color-text-inverse);
-          outline-offset: 2px;
-        }
+        justify-content: center;
 
         .sun { display: none; }
         .moon { display: block; }
-      }
-
-      .search-trigger {
-        &:hover {
-          background-color: rgba(255, 255, 255, 0.1);
-          border-color: rgba(255, 255, 255, 0.5);
-        }
-
-        &:focus-visible {
-          outline: 2px solid var(--color-text-inverse);
-          outline-offset: 2px;
-        }
-
-        .search-shortcut {
-          background-color: transparent;
-          border-color: rgba(255, 255, 255, 0.4);
-        }
       }
     }
 
@@ -235,16 +222,16 @@ header {
       padding: 0.5rem;
       background: transparent;
       border: none;
-      color: var(--color-text-inverse);
+      color: var(--color-navbar-text);
       min-height: var(--navbar-height);
       align-self: flex-start;
 
       &:hover {
-        background-color: rgba(255, 255, 255, 0.1);
+        background-color: var(--color-navbar-control-hover-bg);
       }
 
       &:focus-visible {
-        outline: 2px solid var(--color-text-inverse);
+        outline: 2px solid var(--color-navbar-focus);
         outline-offset: 2px;
       }
 
@@ -303,8 +290,8 @@ header {
           left: 0;
           right: 0;
           height: 1px;
-          background-color: rgba(255, 255, 255, 0.2);
-          box-shadow: -100vw 0 0 rgba(255, 255, 255, 0.2), 100vw 0 0 rgba(255, 255, 255, 0.2);
+          background-color: var(--color-navbar-border);
+          box-shadow: -100vw 0 0 var(--color-navbar-border), 100vw 0 0 var(--color-navbar-border);
         }
       }
 
@@ -315,8 +302,8 @@ header {
         left: 0;
         right: 0;
         height: 1px;
-        background-color: rgba(255, 255, 255, 0.2);
-        box-shadow: -100vw 0 0 rgba(255, 255, 255, 0.2), 100vw 0 0 rgba(255, 255, 255, 0.2);
+        background-color: var(--color-navbar-border);
+        box-shadow: -100vw 0 0 var(--color-navbar-border), 100vw 0 0 var(--color-navbar-border);
       }
 
       li:last-child a::after {
@@ -367,11 +354,15 @@ header {
   /* Second nav - alleen op desktop */
   .navbar-sub {
     display: none;
-    background-color: var(--color-bg-info);
-    border-bottom: 1px solid var(--color-border);
-    box-shadow: 0 0 0 100vmax var(--color-bg-info);
-    clip-path: inset(0 -100vmax);
+    min-height: auto;
+    margin-top: -0.5rem;
+    padding: 0.5rem 1rem;
+    background-color: var(--color-navbar-bg);
+    box-shadow: none;
+    clip-path: none;
     color: var(--color-text);
+    position: relative;
+    z-index: 1;
 
     @media (min-width: 768px) {
       display: flex;
@@ -387,7 +378,7 @@ header {
 
     a {
       color: var(--color-text);
-      font-size: 1.125rem;
+      font-size: 1.25rem;
 
       &:focus-visible {
         outline-color: var(--color-primary);
@@ -414,7 +405,7 @@ header {
       align-items: center;
       justify-content: center;
       width: 1.5rem;
-      height: 1.5rem;
+      align-self: stretch;
       padding: 0;
       background: transparent;
       border: none;
@@ -442,9 +433,8 @@ header {
     .in-section,
     .has-subnav:has(.subnav-toggle[aria-expanded="true"]) {
       background-color: var(--color-bg-muted);
-      margin: -0.25rem -0.5rem;
-      padding: 0.25rem 0.5rem;
-      border-radius: 2px;
+      margin: -0.25rem -0.5rem -0.5rem;
+      padding: 0.25rem 0.5rem 0.5rem;
     }
 
   }
@@ -452,10 +442,16 @@ header {
   /* Third nav - uitklapbaar panel, alleen op desktop */
   .subnav-panel {
     display: none;
+    position: relative;
     background-color: var(--color-bg-muted);
-    box-shadow: 0 0 0 100vmax var(--color-bg-muted);
-    clip-path: inset(0 -100vmax);
-    margin-top: -0.75rem;
+
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0 -100vmax;
+      background-color: var(--color-bg-muted);
+      z-index: -1;
+    }
 
     @media (min-width: 768px) {
       display: block;

--- a/assets/css/components/search.css
+++ b/assets/css/components/search.css
@@ -5,6 +5,7 @@
   gap: 0.25rem;
   padding: 0.5rem 0.75rem;
   font-size: 0.9375rem;
+  font-weight: normal;
 }
 
 .search-trigger .search-icon {

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -29,6 +29,14 @@
   /* Border kleur */
   --color-border: light-dark(#e2e8f0, #334155);
 
+  /* Menubalk */
+  --color-navbar-bg: var(--color-bg-page);
+  --color-navbar-text: var(--color-text-heading);
+  --color-navbar-border: var(--color-border);
+  --color-navbar-control-border: var(--color-border);
+  --color-navbar-control-hover-bg: var(--color-bg-muted);
+  --color-navbar-focus: var(--color-primary);
+
   /* Highlight kleur voor zoekresultaten */
   --color-highlight: var(--color-bg-info);
   --color-highlight-text: inherit;

--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -42,10 +42,9 @@
 
     <ul class="navbar-right">
       <li>
-        <button class="search-trigger" aria-label="Zoeken" aria-haspopup="dialog">
+        <button class="search-trigger" aria-label="Zoeken (sneltoets: schuine streep, ofwel /)" aria-haspopup="dialog">
           {{- partial "icon.html" "search" -}}
-          <span class="search-trigger-text">Zoeken...</span>
-          <kbd class="search-shortcut">/</kbd>
+          <span class="search-trigger-text">Zoeken</span>
         </button>
       </li>
       <li>


### PR DESCRIPTION
Experiment om de menubalk rustiger te maken: hij loopt mee met de paginakleur (wit in light, donker in dark) i.p.v. rijksblauw, gescheiden door subtiele lijnen — vergelijkbaar met [RVO](https://www.rvo.nl/) en [Regelrecht](https://regelrecht.rijks.app/). Alle navbar-kleuren lopen via nieuwe `--color-navbar-*` tokens, zodat het in één plek terug te draaien is.

## Wat er verandert
- **Menubalk** wit/paginakleur i.p.v. blauw; blauwe footer blijft als anker.
- **Zoeken** als gewoon menu-item (tekst + icoon) i.p.v. knop met kader; de `/`-sneltoets staat nu als hint in het `aria-label`.
- **Zoeken + thema-knop** delen hetzelfde hover-vlak (gelijke hoogte/afronding) en liggen gelijk met het hoofdmenu.
- **Subnavigatie** loopt mee met de pagina, dichter onder het hoofdmenu, grotere fontgrootte.
- **Actieve sectie** krijgt een grijs blok dat aansluit op de panel eronder, met de bovenkant gelijk aan de focus-rand.
- **Focus-outlines** overal vierkant (consistent met de rest van de site) en niet meer afgekapt.

## Testen
- Werkt in light én dark mode, desktop en mobiel.
- Toetsenbordnavigatie door de hele balk gecontroleerd (focus-outlines compleet).
- Pre-commit: htmltest (74 docs, geen broken links) en hugo-build slagen.

Graag als experiment bekijken — makkelijk terug te draaien via de tokens.