### PR TITLE
Fix dode preview-links in weekly 24 juni

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -14,9 +14,6 @@ IgnoreURLs:
   - realisatieibds.pleio.nl
   - docs.rijksapp.nl
   - fmis.belastingdienst.nl
-  # Ephemere PR-preview-omgevingen (verdwijnen zodra de PR sluit); links in
-  # weeklies zijn bewust tijdelijk, dus niet als broken link laten falen.
-  - rig.prd1.gn2.quattro.rijksapps.nl
   # Downloadbestanden (.odt/.pdf) worden ná de Hugo-build gegenereerd
   # (pandoc/Chromium) en bestaan dus niet in de kale build die htmltest checkt.
   - \.odt$

--- a/content/weekly/2026/2026-06-24.md
+++ b/content/weekly/2026/2026-06-24.md
@@ -42,7 +42,7 @@ date: 2026-06-24
 
 ## Berichten / FBS
 
-* **Proefopstelling op ZAD:** de [proefopstelling van het Federatief Berichtenstelsel](https://minbzk.github.io/moza-poc-fbs-berichtenbox/) draait nu op het [ZAD-cluster](https://zad.rijksapp.nl/) bij ODC-Noord. De omgevingen voor de uitvraag- en magazijnservices zijn nu zichtbaar via hun eigen Swagger UI's. Je kunt meekijken bij de [uitvraagservice](https://uitvraag-pr-104-mpfb-8wh.rig.prd1.gn2.quattro.rijksapps.nl/q/swagger-ui) en de [magazijnservice](https://magazijna-pr-104-mpfm-w3h.rig.prd1.gn2.quattro.rijksapps.nl/q/swagger-ui). Dit zijn tijdelijke preview-omgevingen, dus de links werken mogelijk niet meer als je dit later leest.
+* **Proefopstelling op ZAD:** de [proefopstelling van het Federatief Berichtenstelsel](https://minbzk.github.io/moza-poc-fbs-berichtenbox/) draait nu op het [ZAD-cluster](https://zad.rijksapp.nl/) bij ODC-Noord. De omgevingen voor de uitvraag- en magazijnservices waren zichtbaar via hun eigen Swagger UI's: de uitvraagservice en de magazijnservice. Dit waren tijdelijke preview-omgevingen, die inmiddels niet meer bereikbaar zijn.
 * **Stabielere tests:** we losten een bron van wisselvallige tests op, zodat onze testresultaten betrouwbaarder zijn.
 
 ## Machtigen en mandaten


### PR DESCRIPTION
## Wat

De weekly van 24 juni linkte naar de Swagger UI's van twee FBS-preview-omgevingen (`uitvraag-pr-104-…` en `magazijna-pr-104-…` op het ZAD-preview-cluster). Die PR-preview-deploys zijn niet meer bereikbaar (HTTP 404), waardoor de `htmltest`-linkcheck faalde.

## Wijzigingen

- **`content/weekly/2026/2026-06-24.md`** — de twee dode links omgezet naar platte tekst en de zin in verleden tijd geformuleerd. De inhoud blijft, de kapotte links verdwijnen.
- **`.htmltest.yml`** — de te brede ignore van het hele preview-cluster (`rig.prd1.gn2.quattro.rijksapps.nl`) verwijderd. Die was met de moza-weekly-PR meegekomen als tijdelijke workaround, maar verborg ook toekomstige breuk op o.a. de eigen site-previews op datzelfde cluster. Nu bij de bron opgelost, dus de linkcheck blijft streng.

## Context

De preview-URLs bleven qua DNS/ingress nog (het cluster antwoordt), maar er draait geen app meer achter (404 op `/`) — kenmerkend voor een opgeruimde PR-preview. Voor een historische weekly horen zulke ephemere links sowieso niet als live-gecheckte link te blijven staan.