### PR TITLE
MOZa Weekly 1 juli 2026

### DIFF
--- a/content/weekly/2026/2026-07-01.md
+++ b/content/weekly/2026/2026-07-01.md
@@ -1,0 +1,76 @@
+---
+title: MOZa Weekly 1 juli 2026
+date: 2026-07-01
+---
+
+## Algemeen
+
+* **Ondernemer in zwaar weer:** we maakten kennis met de collega's die werken aan de levensgebeurtenis "de ondernemer in zwaar weer". Uit het werk dat daar is verzet komen herkenbare patronen. Gegevensuitwisseling is hier een groot thema, zodat ondernemers niet steeds dezelfde informatie hoeven aan te leveren als zij doorgaan naar het volgende loket. We verkennen de komende tijd hoe we kunnen samenwerken.
+* **Start van werksessies:** in recente gesprekken met onze stakeholders merken we dat nog niet iedereen een volledig beeld heeft van wat MOZa doet. Er zijn veel begripsvragen, die we met platen en slides goed kunnen beantwoorden. Na de zomer organiseert MOZa daarom elke vier weken een werksessie op woensdagochtend. Zo stemmen we met partijen af over de stappen, uitdagingen en voortgang. Dit is een uitbreiding van de gesprekken die we de afgelopen tijd met de Belastingdienst hebben gevoerd, en waar we in ieder geval de KVK en RVO voor gaan uitnodigen. Wil je ook aanhaken? Neem dan even [contact](/contact) met ons op.
+* **Dag van de toekomst geëvalueerd:** we blikten samen met [Digilab](https://digilab.overheid.nl/) terug op de [Dag van de toekomst: ondernemer centraal](https://digilab.pleio.nl/groups/view/c182ef44-4cf1-4912-9afa-da3e8b509f32/evenementen-algemeen/events/view/969b45cd-7057-4251-a949-32214fe43663/dag-van-de-toekomst-ondernemer-centraal-en-regeldruk). We kijken terug op een geslaagde dag met mooie verbindingen en overheidsbrede samenwerking. Tegelijk is duidelijk dat "de oplossing" er nog niet ligt en dat we nog werk te verzetten hebben.
+* **Team Lamarr van start:** rondom UX, gebruikersonderzoek, klantreizen en prototypes hebben we een team gevormd. Het team heet Lamarr, naar uitvinder Hedy Lamarr, die aan de basis stond van draadloze technologie zoals wifi en bluetooth. Het team werkt aan een eigen werkwijze: van concept, via goede UX, naar een frontend die we kunnen uitbouwen tot een volwaardige oplossing.
+* **Werkwijze scherper beschrijven:** we werken aan een betere uitleg van onze werkwijze, die we nu nog "prototypend beleid maken" noemen. We willen goed onder woorden brengen wat we doen.
+* **Versterking gezocht:** we hebben veel werk te verzetten en daarom zoeken we nieuwe collega's. Er staat nu een vacature open voor een Software/AI Engineer voor de [Digitale Assistent](/onderwerpen/digitale-assistent/). [Bekijk en deel de vacature — en bij interesse zien we je sollicitatie graag verschijnen.](https://www.linkedin.com/posts/rijksorganisatie-odi_vacature-alert-wil-jij-ai-inzetten-voor-activity-7477290347702759424-igIa)
+
+## Gebruikersonderzoek
+
+* **Inspirerende UX-dag:** op maandag 22 juni hadden we een UX-dag waarbij het team vooruit heeft gekeken. Een leuke en inspirerende dag met veel en diverse uitkomsten. De komende periode is er weer genoeg te doen.
+* **Volgende onderzoek "Berichtenbox" gepland:** we werkten de planning uit voor het volgende gebruikersonderzoek van half tot eind augustus. We maken het [prototype](https://proef.moza.rijksapp.dev/moza/) hiervoor gereed en leggen gebruikers specifiek de Berichtenbox voor.
+* **Invulling ondernemerspanel:** het is fijn om periodiek aan een vaste groep gebruikers vragen te kunnen stellen. Hiervoor gaan we aanhaken op het ondernemerspanel van EZK. Binnenkort doen we een eerste onderzoek om hier ervaring mee op te doen. Ook loopt er vanuit Logius een aanbesteding voor het werven van meer kandidaten voor gebruikersonderzoeken. Hierin worden ondernemers nu ook meegenomen.
+
+## Notificatiedienst
+
+* **MVP opzet NMC:** de focus van deze sprint ligt op een eerste versie van het Notificatie Management Component (NMC). We verwerkten meerdere review-rondes op de code, werkten de documentatie bij en zetten een eerste testversie op het [ZAD-cluster](https://zad.rijksapp.nl/).
+* **Eerste contouren NMC-portaal:** we schetsten digitaal de eerste contouren van het self-serviceportaal voor het NMC. Het doel is zo snel mogelijk een versie te hebben die we als demo kunnen tonen.
+* **Gesprekken met partijen:** we voerden veel gesprekken over de notificatiedienst. Met de Belastingdienst diepten we begrippen uit en deden we nieuwe inzichten op. Samen met de Belastingdienst zetten we in op een eerste MVP, waarbij nog niet alles hoeft te werken. Daarnaast hebben we geleerd dat nog niet alle stakeholders goed zijn meegenomen in wat we momenteel realiseren. De komende tijd besteden we hier samen met Obis aandacht aan.
+* **Beheer en bewaking:** we werkten de health check- en alerting-service bij, zodat we de omgeving beter in de gaten kunnen houden.
+
+## Profielservice
+
+* **Verbeteringen in kaart:** we brengen functionele en technische verbeteringen van de [profielservice](/onderwerpen/profielservice/) in kaart. De afgelopen sprint lag de nadruk vooral op de notificatiedienst, dus inhoudelijk was er op de profielservice weinig voortgang.
+* **Waar draait de profielservice?:** we bepalen nog waar de profielservice komt te draaien. Hierover lopen verschillende gesprekken. Met de KVK verkennen we of het logischer is om functies die nu in de profielservice zitten, dichter tegen het handelsregister te plaatsen. Dit werken we de komende tijd verder uit.
+* **Logboek Dataverwerkingen:** we werkten het Logboek Dataverwerkingen bij naar versie 1.0.0 van de standaard. Ook voegden we ondersteuning voor PostgreSQL toe. Zo maken we onze proefomgeving op het [ZAD-cluster](https://zad.rijksapp.nl/) efficiënter, want de eerdere versie op basis van ClickHouse vroeg veel geheugen.
+
+## Architectuur
+
+* **Beschrijvende architectuur:** we verwerkten de laatste feedback in het positioneringsdocument over de interactiedienstverlening van MijnOverheid. We boden een 0.9-versie van dit document en de ontwerpleidraad aan.
+
+## Berichten / FBS
+
+* **OpenFSC op ZAD:** we werken aan het uitrollen van [OpenFSC](https://fsc-standaard.nl/hoe-werkt-fsc/) op het [ZAD-cluster](https://zad.rijksapp.nl/). Zo kunnen onze projecten hiermee verbinden voor test- en acceptatiedoeleinden. We zetten het project op met de basis, de governance, testcertificaten en een directory. Het is nog even leren hoe het precies werkt, en dat lukt stap voor stap.
+* **Aanpak toegelicht:** we begonnen aan een document dat onze aanpak en keuzes rond de [proefopstelling van het Federatief Berichtenstelsel](https://minbzk.github.io/moza-poc-fbs-berichtenbox/) toelicht.
+* **Samenwerking verstevigd:** we hadden een constructief gesprek met Logius en BZK over het [Federatief Berichtenstelsel](/onderwerpen/berichten-fbs/). We gaan de samenwerking verder verstevigen. Ook de NVWA toonde interesse in FBS, net als in de profiel- en notificatieservice.
+
+## Digitale Assistent
+
+* **Co-creatiedag:** we verdiepten ons een hele dag in de [Digitale Assistent](/onderwerpen/digitale-assistent/) tijdens een co-creatiedag bij de Belastingdienst in Utrecht. We begonnen met een "postcard from the future": wat zeggen ondernemers in 2028 over MOZa met de Digitale Assistent? Daaruit kwamen wensen als eenvoud, snelheid en richting geven. We brachten kansen, risico's en verbeterpunten in beeld en vertaalden de behoeften van ondernemers naar oplossingen.
+* **Design sprint:** in een compacte design sprint verdiepten we de Digitale Assistent verder. De punten voor de expertreview pakken we nu op.
+* **Kansen bij Logius:** in een workshop van Logius keken we hoe we de Digitale Assistent breder kunnen integreren en toepassen. Er liggen mooie kansen om hier nieuwe concepten voor te ontwikkelen.
+* **Gebruikersonderzoek gepland:** we maakten een eerste planning voor gebruikersonderzoeken rond de Digitale Assistent.
+
+## Regelhulpen, RegelRecht en machine-uitvoerbare wetgeving
+
+* **Financieel CV:** we maakten de scope-documentatie voor Financieel CV, samen met het RVO Kenniscentrum Regelhulpen, en zetten dit in de [RegelRecht](https://regelrecht.rijks.app/)-editor. We kiezen er nu voor om ons op Financieel CV te richten en stopten voorlopig met de regelhulp voor de CSRD.
+* **Kwaliteitsmanagement:** we maakten een plan om te starten met kwaliteitsmanagement.
+* **Toekomst regelhulpen:** we spraken over de toekomst van de regelhulpen. De waarde van machine-uitvoerbare regelhulpen wordt gezien. Het is nu aan RVO om hier een plan voor te maken, maar waar het kan, helpen wij natuurlijk graag mee.
+
+## Agenda
+
+💡 Wist je dat we (bijna) elke maandag samenwerken op het Beatrixpark in Den Haag? Wil je een keer aanhaken, dan ben je van harte welkom.
+
+**MOZa**
+
+* Teamoverleg - 1 juli
+* Samenwerkdag met Logius - 1 juli
+* Regieteam - 2 juli
+* MOZa Pulse - 16 juli
+* Stuurgroep - 16 juli
+
+**Evenementen**
+
+* [Omnichannel: ID-wallets in overheidsdienstverlening](https://www.gebruikercentraal.nl/agenda/online-bijeenkomst-omnichannel-id-wallets-in-overheidsdienstverlening/) - 2 juli (online)
+* [Hackathon Transparantie App](https://www.geonovum.nl/agenda/hackathon-transparantie-app-9-en-10-juli) - 9 & 10 juli
+* Common Ground Fieldlab - 14 & 15 september
+* Business Wallet B2G - 22 of 23 september
+* [Europe goes Once-Only: the Netherlands](https://www.digitaleoverheid.nl/evenementen/europe-goes-once-only-the-netherlands/) - 24 & 25 september
+* [IBDS-Stelseldag 2027](https://www.digitaleoverheid.nl/evenementen/ibds-stelseldag-2027/) - 3 februari 2027


### PR DESCRIPTION
Nieuwe editie van de MOZa Weekly voor 1 juli 2026.

## Inhoud
- **Algemeen:** ondernemer in zwaar weer, start van vierwekelijkse werksessies na de zomer, evaluatie Dag van de toekomst, start van team Lamarr, werkwijze scherper beschrijven, en een openstaande vacature (Software/AI Engineer voor de Digitale Assistent).
- **Gebruikersonderzoek:** UX-dag, volgend onderzoek "Berichtenbox" (half–eind augustus), aanhaken op het ondernemerspanel van EZK.
- **Notificatiedienst:** eerste MVP-opzet en portaal-contouren van het NMC, gesprekken met de Belastingdienst, beheer en bewaking.
- **Profielservice:** verbeteringen in kaart, landingsplek in gesprek met de KVK, Logboek Dataverwerkingen 1.0.0 + PostgreSQL.
- **Architectuur:** positioneringsdocument interactiedienstverlening (0.9).
- **Berichten / FBS:** OpenFSC op ZAD, aanpak-document, samenwerking met Logius en BZK.
- **Digitale Assistent:** co-creatiedag, design sprint, kansen bij Logius, gebruikersonderzoek gepland.
- **Regelhulpen / RegelRecht:** Financieel CV, kwaliteitsmanagement, toekomst regelhulpen.
- Agenda cumulatief bijgewerkt.

## Let op
De `htmltest`-linkcheck in de pre-commit hook faalt op verlopen tijdelijke preview-links in de weekly van 24 juni (`uitvraag-pr-104…`, `magazijna-pr-104…`), niet op deze editie. De `hugo-build` slaagt schoon.