### PR TITLE
MOZa Weekly 8 juli 2026

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,4 @@ MATTERMOST_TOKEN=
 # Optioneel — defaults staan rechts van het =
 MOZA_WEEKLY_SERVER_URL=https://digilab.overheid.nl/chat
 MOZA_WEEKLY_TEAM=mijnoverheid-zakelijk
-MOZA_WEEKLY_CHANNELS=check-in,agenda
+MOZA_WEEKLY_CHANNELS=check-in,agenda,sprint-faq

--- a/content/weekly/2026/2026-07-08.md
+++ b/content/weekly/2026/2026-07-08.md
@@ -1,0 +1,74 @@
+---
+title: MOZa Weekly 8 juli 2026
+date: 2026-07-08
+---
+
+## Algemeen
+
+* **Statusoverzicht van bouwblokken:** we werken aan een overzicht van bouwblokken waar we momenteel aan werken, voor de Wet modernisering elektronisch bestuurlijk verkeer (WMEBV). Dit overzicht volgt de architectuur en laat per bouwblok zien welk team eraan werkt, wat de gewenste planning is en wat de uitdagingen zijn. We zoeken daarbij nog naar een vorm om dit ook publiek te delen.
+* **MOZa Regieteam:** in het regieteam bespraken we de stand van zaken van de bouwblokken aan de hand van het statusoverzicht. We spraken onder andere over hoe we samen met andere organisaties verder werken: met gezamenlijke werksessies rond de notificatiedienst en met de mogelijkheid voor individuele verdieping per organisatie. Ook hebben we de stuurgroep van 16 juli voorbereid, met daarin onder andere het delen van de stand van zaken en een demo van de notificatiedienst.
+* **Tijdlijnen aangescherpt:** voor de notificatie- en profieldienst hebben we de tijdlijnen voor de komende periode aangescherpt. We brachten daarbij lagen aan in de functionaliteiten. Van daaruit geven we aan wanneer het gewenst is dat een functionaliteit beschikbaar is. We brengen ook in kaart of dat juridisch, technisch en operationeel haalbaar is, of dat er nog uitdagingen zijn. Deze tijdlijnen verwerken we in het statusoverzicht.
+* **Juristen eerder betrekken:** we gaan het juridische team van BZK eerder in het proces betrekken, zodat zij ook eerder een beeld kunnen vormen van wat eraan komt. Eerder betekent in dit geval: al vanaf het moment dat de gebruikersonderzoeken starten. Concreet laten we dit team aansluiten bij onze sprint-FAQ, zodat ze vroeg kunnen meekijken en meteen vragen stellen.
+* **Portaal voor dienstverleners:** we werken aan een concept voor een portaal waar dienstverleners kunnen zien welke bouwblokken beschikbaar zijn. Denk hierbij aan de notificatie- en profieldienst. Het doel is dat je deze diensten eenvoudig kunt uitproberen en er in een latere fase op kunt aansluiten. Je kunt ze ook configureren en rapportages inzien, bijvoorbeeld over het gebruik.
+
+## Gebruikersonderzoek
+
+* **Berichtenbox klaar voor onderzoek:** we pasten de interface van de Berichtenbox in de proefopstelling aan voor het gebruikersonderzoek op 13 en 14 juli. We nemen gebruikers mee in een flow waar verschillende MijnOmgevingen worden ingezet. De acties vanuit de MijnOmgevingen werken daarbij synchroon: markeer je een bericht in het ene portaal, dan zie je dat ook in het andere portaal. Ter illustratie een mogelijke flow:
+    * Je krijgt een bericht in je mailbox.
+    * Via MijnOverheid ga je naar MijnOverheid Zakelijk en vindt daar het bericht.
+    * Van daaruit klik je door naar Mijn Belastingdienst Zakelijk.
+    * In Mijn Belastingdienst Zakelijk markeer je het bericht als belangrijk.
+    * Op MijnOverheid Zakelijk staat dit bericht nu ook gemarkeerd.
+
+## Notificatiedienst
+
+* **Eerste ruwe versie van het NMC werkt:** we hebben een grote stap gezet met het Notificatie Management Component (NMC). De eerste ruwe versie draait op het [ZAD-cluster](https://zad.rijksapp.nl/). We konden echt e-mails versturen, met gegevens uit de [profieldienst](/onderwerpen/profielservice/). Een mooie mijlpaal. We maakten ook een korte demo die de hele flow laat zien, van het versturen tot de status "bezorgd".
+* **Zo werkt de flow:** een dienstverlener biedt een notificatie aan voor iemand met een BSN of KVK-nummer. Het NMC zoekt in de profieldienst de juiste partij en het e-mailadres op. Daarna stuurt het de notificatie naar NotifyNL, dat de e-mail bezorgt. NotifyNL koppelt terug of het bericht is afgeleverd. Die terugkoppeling spelen we door aan de dienstverlener.
+* **Beheer en bewaking:** we werkten verder aan de health check- en alerting-service en bereidden de bewaking voor. Zo houden we de omgeving goed in de gaten richting lancering.
+* **Toewerken naar lancering:** we spraken met Logius verder over hoe we de notificatiedienst kunnen laten landen. Hierover met elkaar in gesprek zijn is belangrijk, omdat er een breder team aan collega's betrokken moet worden op het moment dat we deze dienst bij Logius in beheer willen nemen. Nu er een eerste ruwe versie is, betekent dit ook dat we dit gesprek beter kunnen voeren.
+
+## Profieldienst
+
+* **Code review afgerond:** ondersteund door AI hebben we een code review van de profieldienst gedaan. De bevindingen staan als tickets op de backlog en worden opgepakt. Een aantal lessen hebben we meteen ook toegepast op het NMC.
+* **Hergebruik van registers onderzocht:** we onderzochten of we een bestaand register kunnen hergebruiken in de profieldienst. Zo bekijken we of dat haalbaar en logisch is.
+
+## Machtigen en mandaten
+
+* **Werksessie "wie mag wat":** op 30 juni hielden we de werksessie over authenticatie, autorisatie, machtigen en mandaten. Met het team brachten we verschillende beelden en meningen bij elkaar. We werkten met persona's en zetten de eerste stappen naar een gezamenlijk beeld, waarbij nu ook veel aandacht uitgaat naar het vergroten van het kennisniveau. Zowel functioneel als technisch komen hierbij veel uitdagingen op tafel.
+* **Klantreis in beeld:** we maakten een service blueprint voor de klantreis van het aanvragen van een subsidie, met de ondernemer centraal. Deze inzichten gebruiken we om het verhaal van "de overheid van de nabije toekomst" te verrijken.
+* **Inzicht:** in een sessie over authenticatie en autorisatie leerden we dat RVO uitgaat van een "trusted party". Zolang een andere partij dezelfde taal spreekt, kan een koppeling al werken. De vraag blijft hoe we die taal spreken zonder dat er te veel dialecten ontstaan.
+* **Vervolg gepland:** we plannen een vervolgsessie met een bredere groep. De eerste namen daarvoor kwamen al langs in het regieteam.
+
+## Berichten / FBS
+
+* **Aanpak en keuzes vastgelegd:** we voegden [een document](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/blob/main/docs/aanpak-en-keuzes.md) toe dat onze aanpak en keuzes rond de proefopstelling van het Federatief Berichtenstelsel toelicht.
+* **Samenwerking met Logius:** we hebben aan Logius en BZK toegelicht wat we het afgelopen halfjaar hebben gedaan. We zijn uitgegaan van de architectuur die al eerder voor FBS is uitgedacht, hebben die aangepast met de kennis van nu en maken daar nu een proefopstelling voor. Logius is nu goed aangehaakt op de proefopstelling en we zetten de samenwerking de komende tijd voort.
+* **FBS draait op ZAD:** de proefopstelling draait nu in een eerste opstelling op het ZAD-cluster, met een nagebootste profieldienst. Zo bouwen we de omgeving stap voor stap op.
+* **Implementatie FSC:** we werken aan [Federated Service Connectivity (FSC)](https://fsc-standaard.nl/hoe-werkt-fsc/) op het ZAD-cluster, met alle beveiliging die daarbij hoort. Samen met de collega's die aan ZAD werken, zorgen we dat ook aan het ZAD-cluster aanpassingen worden gemaakt. Dit proces verloopt snel, waardoor de basis voor FSC nu al draait.
+    * **Nieuwtje over FSC:** FSC staat nu op een lijst van de Europese Commissie, te vergelijken met de Nederlandse "pas toe of leg uit". Dat bevestigt dat onze inzet op FSC ook Europees goed past. Meer lees je bij [Interoperable Europe](https://interoperable-europe.ec.europa.eu/collection/api4dt/solution/federated-service-connectivity-core-specification).
+
+## Design system
+
+* **NLDD in Next.js:** we onderzoeken hoe we NLDD kunnen combineren met Next.js. Dat lukt nog niet helemaal, maar het onderzoek loopt door.
+* **Van vaste tools naar HTML:** we merken dat PowerPoint en documenten ons minder vrijheid geven. Steeds vaker vertelt HTML ons verhaal beter. Daarom maakten we ook [de persona's en de klantreis in HTML](https://cx-moza.rijksapp.dev/).
+* **Eén omgeving voor demo en proef:** we werken toe naar één omgeving waarin we zowel fictieve als echte koppelingen met diensten kunnen laten zien. Dat maakt het onderhoud eenvoudiger, terwijl we tegelijk de ontwikkelde diensten echt beproeven. Gebruikersonderzoeken en de demo's komen daarmee ook dichter bij elkaar te liggen.
+
+## Agenda
+
+💡 Wist je dat we (bijna) elke maandag samenwerken op het Beatrixpark in Den Haag? Wil je een keer aanhaken, dan ben je van harte welkom.
+
+**MOZa**
+
+* Gebruikersonderzoek Berichtenbox - 13 & 14 juli
+* MOZa Pulse - 16 juli
+* Stuurgroep - 16 juli
+* Regieteam - 6 augustus (mogelijk september vanwege de vakantieperiode)
+* MOZa teamdag - 8 september (inclusief afsluiter met MOZa regieteam)
+
+**Evenementen**
+
+* [Hackathon Transparantie App](https://www.geonovum.nl/agenda/hackathon-transparantie-app-9-en-10-juli) - 9 & 10 juli
+* [Common Ground Fieldlab](https://commonground.nl/events/view/1a31088b-5794-466c-8bf4-79be0a678eee/common-ground-fieldlab-14-en-15-september-2026) - 14 & 15 september
+* Business Wallet B2G - 22 of 23 september
+* [Europe goes Once-Only: the Netherlands](https://www.digitaleoverheid.nl/evenementen/europe-goes-once-only-the-netherlands/) - 24 & 25 september
+* [IBDS-Stelseldag 2027](https://www.digitaleoverheid.nl/evenementen/ibds-stelseldag-2027/) - 3 februari 2027

--- a/scripts/moza-weekly/README.md
+++ b/scripts/moza-weekly/README.md
@@ -2,7 +2,7 @@
 
 Drie-staps Python-pipeline die input verzamelt voor de wekelijkse MOZa Weekly-publicatie.
 
-1. **`fetch.py`** haalt berichten en threads op uit Mattermost-kanalen (default: `check-in`, `agenda`) en schrijft een gestructureerd YAML-bestand.
+1. **`fetch.py`** haalt berichten en threads op uit Mattermost-kanalen (default: `check-in`, `agenda`, `sprint-faq`) en schrijft een gestructureerd YAML-bestand.
 2. **`anonymize.py`** schrijft een geanonimiseerde JSON-variant van die YAML — bedoeld als veilige LLM-input voor de MOZa Weekly skill.
 3. **`render.py`** rendert het YAML-bestand naar een single-file HTML-rapport in de nldd-stijl (voor menselijke lezers).
 

--- a/scripts/moza-weekly/fetch.py
+++ b/scripts/moza-weekly/fetch.py
@@ -54,7 +54,7 @@ GENERATOR = "moza-weekly fetch.py v0.1.0"
 NL_TZ = ZoneInfo("Europe/Amsterdam")
 DEFAULT_SERVER = "https://digilab.overheid.nl/chat"
 DEFAULT_TEAM = "mijnoverheid-zakelijk"
-DEFAULT_CHANNELS = "check-in,agenda"
+DEFAULT_CHANNELS = "check-in,agenda,sprint-faq"
 
 # Exit-codes
 EXIT_OK = 0


### PR DESCRIPTION
## MOZa Weekly 8 juli 2026

Nieuwe weekly-editie: `content/weekly/2026/2026-07-08.md`.

Belangrijkste onderwerpen:
- **Notificatiedienst:** eerste ruwe versie van het NMC draait op het ZAD-cluster (mijlpaal), inclusief demo van de flow.
- **Machtigen en mandaten:** werksessie "wie mag wat" van 30 juni, service blueprint subsidie-klantreis, RVO trusted-party-inzicht.
- **Berichten / FBS:** aanpak-en-keuzes-document, FBS + FSC op ZAD, FSC op de Europese lijst.
- **Algemeen:** MOZa Regieteam, statusoverzicht bouwblokken, juristen eerder betrekken.
- **Gebruikersonderzoek:** Berichtenbox klaar voor onderzoek op 13-14 juli.

Redactioneel: geen persoonsnamen, NDD bewust weggelaten, term consequent "profieldienst", taalreview verwerkt. `just check` is groen (htmltest + hugo-build).

Let op: deze branch bevat ook commit `b3b3bfa` (sprint-faq-kanaal toevoegen aan de weekly-input-tooling), die nog niet op `main` stond.
