### PR TITLE
Download-opties (Markdown, ODF, PDF) op MOZa Weekly-pagina's

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -3,7 +3,7 @@ FROM alpine:3.21 AS builder
 ARG HUGO_VERSION=0.163.1
 ARG PANDOC_VERSION=3.10
 
-RUN apk add --no-cache wget git nodejs npm chromium zip unzip \
+RUN apk add --no-cache wget git nodejs npm chromium font-noto-emoji zip unzip \
     && wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-amd64.tar.gz \
     && tar -xzf hugo.tar.gz -C /usr/local/bin \
     && rm hugo.tar.gz \

--- a/content/weekly/_index.md
+++ b/content/weekly/_index.md
@@ -7,6 +7,8 @@ outputs:
   - llms
   - llmsfull
   - llmsrecent
+cascade:
+  download: true
 ---
 
 Wil je updates ontvangen? Gebruik de [RSS feed](index.xml).


### PR DESCRIPTION
## Wat

MOZa Weekly-pagina's krijgen in de zijbalk de downloadknoppen **Markdown**, **Open document (ODF)** en **PDF**, naast de bestaande "Op deze pagina"-inhoudsopgave. Daarnaast rendert de container nu emoji correct in de PDF-export.

## Hoe

**1. Downloads aanzetten** - een cascade in `content/weekly/_index.md` zet `download: true` op alle weekly-pagina's:

- `page-aside.html` toont het downloadblok bij `download: true`.
- `home.download.json` neemt de pagina's op in het manifest.
- `scripts/downloads/render-downloads.js` genereert ná de build `.odt` (pandoc) en `.pdf` (Chromium). `container/Containerfile` draait die stap in productie.

Markdown-output bestond al voor alle `page`-types (`outputs.page`).

**2. Emoji in de PDF** - `container/Containerfile` installeert nu `font-noto-emoji`. De headless Chromium die de PDF's print had geen emoji-font, waardoor bijvoorbeeld de lamp-emoji in de agenda-intro als "tofu" verscheen. Met de Noto Color Emoji-font rendert die correct. HTML en ODF waren al goed.

## Verificatie

- Lokale preview: een weekly-pagina toont nu zowel "Op deze pagina" als "Download deze pagina" met de drie formaten.
- `just build`: 30x `.odt` en 30x `.pdf` gegenereerd voor de weekly's; PDF geldig (A4, meerdere pagina's).
- Emoji-fix getest in een Alpine 3.21-container: headless Chromium rendert de emoji in kleur in de PDF met `font-noto-emoji`.
- `just check` groen.

## Let op

De build genereert nu downloads voor alle ~30 weekly-edities (voorheen alleen de intentieverklaring), dus de productie/preview-build wordt iets zwaarder.
