### PR TITLE
Herschrijf interne links in Markdown-output naar hun .md-variant

### DIFF
--- a/layouts/_partials/clean-markdown.html
+++ b/layouts/_partials/clean-markdown.html
@@ -1,7 +1,0 @@
-{{- /* Strip Hugo-shortcodes en GitHub-alerts uit ruwe Markdown. Aanroep: partial "clean-markdown" .RawContent */ -}}
-{{- $content := . -}}
-{{- $content = replaceRE `\{\{<[^>]+>\}\}` "" $content -}}
-{{- $content = replaceRE `\{\{%[^%]+%\}\}` "" $content -}}
-{{- $content = replaceRE `>\s*\[!(NOTE|WARNING|TIP|IMPORTANT|INFO|CAUTION)\]` "" $content -}}
-{{- $content = replaceRE `\n{3,}` "\n\n" $content -}}
-{{- return ($content | strings.TrimSpace | safeHTML) -}}

--- a/layouts/_partials/markdown-body.html
+++ b/layouts/_partials/markdown-body.html
@@ -1,0 +1,47 @@
+{{- /*
+  Schoont RawContent op en herschrijft interne links naar hun .md-variant.
+  Aanroepen met de oorsprongpagina als context (niet met een string): .GetPage
+  resolvet relatieve paden t.o.v. die pagina.
+*/ -}}
+{{- $p := . -}}
+{{- $content := .RawContent -}}
+
+{{- $content = replaceRE `\{\{<[^>]+>\}\}` "" $content -}}
+{{- $content = replaceRE `\{\{%[^%]+%\}\}` "" $content -}}
+{{- $content = replaceRE `>\s*\[!(NOTE|WARNING|TIP|IMPORTANT|INFO|CAUTION)\]` "" $content -}}
+
+{{- /* findRESubmatch-groepen: 0=geheel, 1='!', 2=tekst, 3=doel */ -}}
+{{- range findRESubmatch `(!?)\[([^\]]*)\]\(([^)\s]+)\)` $content -}}
+  {{- $whole := index . 0 -}}
+  {{- $text := index . 2 -}}
+  {{- $dest := index . 3 -}}
+  {{- if eq (index . 1) "!" }}{{ continue }}{{ end -}}
+  {{- if hasPrefix $dest "<" }}{{ continue }}{{ end -}}
+  {{- $u := urls.Parse $dest -}}
+  {{- if or $u.IsAbs (hasPrefix $dest "#") (hasPrefix $dest "//") (hasPrefix $dest "mailto:") (hasPrefix $dest "tel:") (not $u.Path) }}{{ continue }}{{ end -}}
+  {{- $path := strings.TrimPrefix "./" $u.Path -}}
+  {{- $new := "" -}}
+  {{- $target := $p.GetPage $path -}}
+  {{- with $target -}}
+    {{- $isMd := false -}}
+    {{- with .File }}{{ if eq .Ext "md" }}{{ $isMd = true }}{{ end }}{{ end -}}
+    {{- $mdOut := .OutputFormats.Get "markdown" -}}
+    {{- if and $isMd $mdOut -}}
+      {{- $new = $mdOut.RelPermalink -}}
+    {{- else -}}
+      {{- $new = .RelPermalink -}}
+    {{- end -}}
+  {{- else -}}
+    {{- with or ($p.Resources.Get $path) (resources.Get $path) -}}
+      {{- $new = .RelPermalink -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $new -}}
+    {{- with $u.RawQuery }}{{ $new = printf "%s?%s" $new . }}{{ end -}}
+    {{- with $u.Fragment }}{{ $new = printf "%s#%s" $new . }}{{ end -}}
+    {{- $content = replace $content $whole (printf "[%s](%s)" $text $new) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $content = replaceRE `\n{3,}` "\n\n" $content -}}
+{{- return ($content | strings.TrimSpace | safeHTML) -}}

--- a/layouts/home.llmsfull.txt
+++ b/layouts/home.llmsfull.txt
@@ -12,7 +12,7 @@
 
 ## {{ .Title }}
 
-{{ partial "clean-markdown" .RawContent }}
+{{ partial "markdown-body" . }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -21,7 +21,7 @@
 
 ## {{ .Title }}
 
-{{ partial "clean-markdown" .RawContent }}
+{{ partial "markdown-body" . }}
 {{- end }}
 
 # Handboek
@@ -31,7 +31,7 @@ Interne documentatie voor het MOZa team.
 
 ## {{ .Title }}
 
-{{ partial "clean-markdown" .RawContent }}
+{{ partial "markdown-body" . }}
 {{- end }}
 
 # Weekly Updates
@@ -41,7 +41,7 @@ De laatste 10 updates. Voor alle updates, zie [/weekly/llms-full.txt](/weekly/ll
 
 ## {{ .Title }} ({{ .Date | time.Format "2 January 2006" }})
 
-{{ partial "clean-markdown" .RawContent }}
+{{ partial "markdown-body" . }}
 {{- end }}
 
 ---

--- a/layouts/list.llms.txt
+++ b/layouts/list.llms.txt
@@ -3,8 +3,8 @@
 {{ with .Description }}
 > {{ . }}
 {{ end }}
-{{- with .RawContent -}}
-{{ partial "clean-markdown" . }}
+{{- if .RawContent -}}
+{{ partial "markdown-body" . }}
 
 {{ end -}}
 ## Pagina's in deze sectie

--- a/layouts/list.llmsfull.txt
+++ b/layouts/list.llmsfull.txt
@@ -3,8 +3,8 @@
 {{ with .Description }}
 > {{ . }}
 {{ end }}
-{{- with .RawContent -}}
-{{ partial "clean-markdown" . }}
+{{- if .RawContent -}}
+{{ partial "markdown-body" . }}
 {{ end -}}
 {{- range .Pages.ByWeight }}
 
@@ -12,7 +12,7 @@
 {{ with .Description }}
 > {{ . }}
 {{ end }}
-{{ partial "clean-markdown" .RawContent }}
+{{ partial "markdown-body" . }}
 {{- end }}
 
 ---

--- a/layouts/page.markdown.md
+++ b/layouts/page.markdown.md
@@ -10,4 +10,4 @@ last_updated: {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}
 
 # {{ .Title }}
 
-{{ partial "clean-markdown" .RawContent }}
+{{ partial "markdown-body" . }}

--- a/layouts/weekly/list.llmsfull.txt
+++ b/layouts/weekly/list.llmsfull.txt
@@ -13,7 +13,7 @@
 
 ## {{ .Title }} ({{ .Date | time.Format "2 January 2006" }})
 
-{{ partial "clean-markdown" .RawContent }}
+{{ partial "markdown-body" . }}
 {{- end }}
 
 ---

--- a/layouts/weekly/list.llmsrecent.txt
+++ b/layouts/weekly/list.llmsrecent.txt
@@ -13,7 +13,7 @@
 
 ## {{ .Title }} ({{ .Date | time.Format "2 January 2006" }})
 
-{{ partial "clean-markdown" .RawContent }}
+{{ partial "markdown-body" . }}
 {{- end }}
 
 ---


### PR DESCRIPTION
## Wat
Interne links in de Markdown-output (`/…/index.md`) wijzen nu naar hun Markdown-variant in plaats van rauwe of verkeerde relatieve links.

## Waarom
`page.markdown.md` serveerde `.RawContent` letterlijk, waardoor Hugo's render-hooks niet draaiden en interne links rauw bleven. Relatieve links (`../../`) losten in de geserveerde `.md` naar de verkeerde pagina op, soms stil naar een bestaande maar verkeerde pagina.

## Hoe
Nieuwe partial `markdown-body` herschrijft interne links via `.GetPage` (dezelfde resolutie als de HTML render-link-hook):
- echte pagina's naar hun `…/index.md`
- secties, home en HTML-page-bundles (rapportages, presentaties) naar de gewone pretty-URL, net als de HTML-site
- extern, mailto, anchor en afbeeldingen onaangeroerd; query en fragment blijven behouden

Toegepast op `page.markdown.md` en de `llms-full`-aggregaties, steeds per oorspronkpagina. Vervangt `clean-markdown`. Links die Hugo zelf niet kan omzetten blijven relatief, identiek aan de HTML-site.
