### PR TITLE
MOZa Weekly 15 juli 2026

### DIFF
--- a/.claude/skills/new-weekly/SKILL.md
+++ b/.claude/skills/new-weekly/SKILL.md
@@ -10,7 +10,11 @@ description: Gebruik bij het maken van een nieuwe MOZa Weekly.
 1. Vraag welke datum (of gebruik vandaag). Sla over als de datum al gegeven is.
 2. **Lees de laatste 3-5 weeklies** in `content/weekly/YYYY/`. Hieruit volgen: huidige sectie-indeling, toon, linkpatronen en de lopende agenda. Kopieer het patroon, schrijf niet vanaf nul.
 3. Run: `hugo new content weekly/YYYY/YYYY-MM-DD.md`.
-4. Vraag input van de gebruiker. Sla over als de input al gegeven is.
+4. Verzamel input (sla over als de input al gegeven is):
+   - Standaardbron is de Mattermost-pipeline: run `just moza-weekly` (zie `scripts/moza-weekly/README.md`). Dat levert drie bestanden op in `tmp/moza-weekly/`.
+   - Gebruik `tmp/moza-weekly/<datum>.anonymized.json` als input. Nooit de `.yaml` of `.html` gebruiken: die bevatten namen.
+   - De gebruiker cureert eventueel de YAML; run daarna `just moza-weekly-anonymize tmp/moza-weekly/<datum>.yaml` om de JSON te verversen.
+   - Vraag de gebruiker om aanvullende input die niet uit Mattermost komt.
 5. Groepeer de input in secties op basis van wat er deze week speelt — secties zijn niet vast, ze volgen de onderwerpen. Laat een sectie weg als er geen inhoud voor is.
 
 ## Secties zijn onderwerp-gedreven

--- a/content/weekly/2026/2026-07-15.md
+++ b/content/weekly/2026/2026-07-15.md
@@ -1,0 +1,56 @@
+---
+title: MOZa Weekly 15 juli 2026
+date: 2026-07-15
+---
+
+## Algemeen
+
+* **Actualiteitenservice gedocumenteerd:** we voegden de [actualiteitenservice](/onderwerpen/actualiteitenservice/) toe aan de onderwerpen op deze site. Op de pagina lees je wat de service beoogd te doen, wat we bouwden en testten, en waarom we de verdere ontwikkeling nu pauzeren. Ook van werk dat we bewust stilzetten delen we zo de lessen.
+* **Componentenoverzicht notifiactie- en profieldienst:** met dit componentenoverzicht geven we inzicht in de stand van zaken van de componenten die onderdeel uitmaken van de notificatie- en profieldienst. Daarbij ook specifiek aandacht voor de uitdagingen waar we tegen aanlopen, de risico's en overige aandachtspunten. We zoeken nog een goede manier om rapportages zoals deze breder te delen.
+* **Stuurgroep voorbereid:** we bereidden de stuurgroep van 16 juli voor. Op de agenda staan onder andere een demo van de notificatiedienst en dienstverleners portaal. En we bespreken de stand van zaken aan de hand van het componentenoverzicht.
+* **Afspraken met VNG:** we maakten procesafspraken met de VNG over hoe zij hun inbreng leveren. De afstemming wordt frequenter, waarbij we elkaar de komende periode elke week spreken.
+* **Sprint FAQ 2.0:** we faciliteerden een vernieuwde opzet van onze eigen sprint FAQ. Onze teams delen vooraf een filmpje, link of presentatie over de afgelopen sprint. Tijdens het overleg zelf is er zo meer ruimte voor vragen. Itererend komen we tot een goed concept voor kennisdeling. Het juridische team van BZK is voortaan ook uitgenodigd voor de sprint FAQ, zodat zij al eerder een beeld kunnen vormen over wat er speelt binnen MOZA.
+* **Ontwikkelen met AI-ondersteuning:** we kregen vragen over hoe wij software bouwen met AI-ondersteuning en of dit vanuit risico perspectief wel goed gaat. Ons korte antwoord is dat de mens verantwoordelijk blijft en de kwaliteit van de software inclusief code op elk moment door anderen kan worden beoordeeld. Goede vragen helpen ons om deze nieuwe manier van werken scherp uit te blijven leggen.
+
+## Notificatiedienst
+
+* **NMC klaar voor de demo:** het Notificatie Management Component (NMC) is klaar voor de demo in de stuurgroep. De NMC praat nu met de acceptatie-omgeving van de [profieldienst](/onderwerpen/profielservice/). De hele flow werkt: een notificatie verzoekt wordt verstuurd vanuit het systeem van een dienstverlener naar het NMC. Het NMC zoekt het e-mailadres op in de profieldienst, verstuurt de e-mail via NotifyNL en geeft de bezorgstatus terug aan de dienstverlener.
+* **Juridisch spoor:** we brachten in kaart of een basisversie van de notificatiedienst per 1 januari 2027 live kan op basis van de huidige wetten. Hierover hebben we gesproken met het juridische team van BZK. Daarnaast hebben we ook een hulpvraag uitgezet bij het MOZa regieteam en trekken we hierin samen op met Obis.
+* **Sjablonen per berichttype:** een dienstverlener kan bij een notificatie nu een type bericht meegeven. Het NMC koppelt dat type automatisch aan het juiste e-mailsjabloon.
+* **Automatisch uitrollen:** het NMC rolt nu automatisch uit naar het ZAD-cluster bij elke goedgekeurde wijziging in de code. Hiermee kunnen we altijd de laatste versie testen.
+* **Beheer en bewaking:** we richtten de alerting en health checks verder in, zo dicht mogelijk bij hoe de beheeromgeving bij Logius er straks uit moet zien. Bij het testen van foutmeldingen van NotifyNL zagen we onverwacht gedrag; we hebben de vraag bij NotifyNL uitgezet.
+
+## Profieldienst
+
+* **Reactie op DPIA:** de juristen reageerden op de DPIA (privacytoets) van de profieldienst. We pakken de opvolging hiervan op.
+* **Kwaliteitscontroles uitgebreid:** we werkten de automatische controles op de code verder uit, zoals linting en checks op bekende kwetsbaarheden.
+* **Gesprekken met de KVK:** we spraken opnieuw met de KVK en hebben daarbij gesproken over de positionering van de profieldienst. Daarbij deden we nieuwe inzichten op over de wettelijke positionering. Ook kan de KVK de profieldienst, of onderdelen daarvan, gebruiken in het eigen landschap.
+
+## Berichten / FBS
+
+* **Berichtenbox via FSC:** we werkten aan het ontsluiten van de Berichtenbox-proefopstelling via [Federated Service Connectivity (FSC)](https://fsc-standaard.nl/hoe-werkt-fsc/) op het ZAD-cluster. Nog niet helemaal af, omdat er nog wat wijzigingen aan dit cluster nodig zijn.
+* **Patroon van Vorderingenoverzicht Rijk verkend:** we maakten een eerste opzet die verkent hoe het patroon achter [Vorderingenoverzicht Rijk](https://vorijk.nl/docs/introductie/) gebruikt kan worden binnen het [Federatief Berichtenstelsel](/onderwerpen/berichten-fbs/).
+
+## Klantreizen en demo omgeving
+
+* **Proef en demo worden één:** we werkten een aanpak uit om toe te werken naar één proefomgeving waar alles op staat. Met een uitbreiding van de flags-functionaliteit zetten we versies naast elkaar. We stemmen met de MOZa teams af welke functionaliteiten van de demo-omgeving over kunnen naar de proefomgeving. Ook maakten we een testopzet om React-componenten in de proefomgeving te gebruiken.
+* **Klantreis subsidieaanvraag groeit:** op de [CX omgeving](https://cx-moza.rijksapp.dev/) zetten we stappen met de klantreis voor de gezamenlijke subsidieaanvraag. We kunnen nu verschillende detailniveaus en vraagstukken tonen, zodat verschillende typen stakeholders er iets aan hebben. [Bekijk de sneak preview](https://cx-moza.rijksapp.dev/klantreizen/gezamenlijke-subsidieaanvraag/index.html) inclusief easter egg. Vind jij 'm?
+* **MijnAmsterdam als proeftuin:** we verkennen of we de broncode van MijnAmsterdam lokaal kunnen draaien, zodat we kunnen experimenteren met MOZa-integraties in een bestaande MijnOmgeving. Parallel bekijken we of de proef met de browser-plugin een vervolg moet krijgen voor deze use cas.
+
+## Agenda
+
+💡 Wist je dat we (bijna) elke maandag samenwerken op het Beatrixpark in Den Haag? Wil je een keer aanhaken, dan ben je van harte welkom.
+
+**MOZa**
+
+* MOZa Pulse - 16 juli
+* Stuurgroep - 16 juli
+* Regieteam - 6 augustus (mogelijk september vanwege de vakantieperiode)
+* MOZa teamdag - 8 september (inclusief afsluiter met MOZa regieteam)
+
+**Evenementen**
+
+* [Common Ground Fieldlab](https://commonground.nl/events/view/1a31088b-5794-466c-8bf4-79be0a678eee/common-ground-fieldlab-14-en-15-september-2026) - 14 & 15 september
+* Business Wallet B2G - 22 of 23 september
+* [Europe goes Once-Only: the Netherlands](https://www.digitaleoverheid.nl/evenementen/europe-goes-once-only-the-netherlands/) - 24 & 25 september
+* [IBDS-Stelseldag 2027](https://www.digitaleoverheid.nl/evenementen/ibds-stelseldag-2027/) - 3 februari 2027

--- a/scripts/moza-weekly/README.md
+++ b/scripts/moza-weekly/README.md
@@ -66,7 +66,7 @@ Output landt in `tmp/moza-weekly/<vandaag>.yaml`, `.anonymized.json` én `.html`
 
 | Default | Wat |
 |---|---|
-| Periode | Vandaag − 7 dagen t/m vandaag |
+| Periode | Vandaag - 6 dagen t/m vandaag (7 kalenderdagen) |
 | Kanalen | uit `MOZA_WEEKLY_CHANNELS` env (of CLI `--channel`) |
 | Output | `tmp/moza-weekly/<einde-datum>.{yaml,html}` |
 

--- a/scripts/moza-weekly/fetch.py
+++ b/scripts/moza-weekly/fetch.py
@@ -88,7 +88,11 @@ def _load_dotenv(path: Path) -> None:
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     p = argparse.ArgumentParser(prog="moza-weekly-fetch", description=__doc__)
-    p.add_argument("--from", dest="date_from", help="YYYY-MM-DD (default: 7 dagen terug)")
+    p.add_argument(
+        "--from",
+        dest="date_from",
+        help="YYYY-MM-DD (default: 6 dagen terug; periode van 7 dagen incl. vandaag)",
+    )
     p.add_argument("--to", dest="date_to", help="YYYY-MM-DD (default: vandaag)")
     p.add_argument("--channel", action="append", default=None, dest="channels")
     p.add_argument("--output", type=Path, default=None)
@@ -109,7 +113,7 @@ def _build_period(date_from: str | None, date_to: str | None) -> Period:
     today = datetime.now(NL_TZ).date()
     end_date = date.fromisoformat(date_to) if date_to else today
     start_date = (
-        date.fromisoformat(date_from) if date_from else end_date - timedelta(days=7)
+        date.fromisoformat(date_from) if date_from else end_date - timedelta(days=6)
     )
     if start_date > end_date:
         raise ValueError(f"--from ({start_date}) ligt na --to ({end_date})")

--- a/scripts/moza-weekly/tests/test_fetch.py
+++ b/scripts/moza-weekly/tests/test_fetch.py
@@ -17,9 +17,9 @@ def test_build_period_explicit_bounds():
     assert (period.end.hour, period.end.minute, period.end.second) == (23, 59, 59)
 
 
-def test_build_period_default_is_seven_days():
+def test_build_period_default_spans_seven_calendar_days():
     period = _build_period(None, None)
-    assert (period.end.date() - period.start.date()) == timedelta(days=7)
+    assert (period.end.date() - period.start.date()) == timedelta(days=6)
 
 
 def test_build_period_rejects_reversed_range():


### PR DESCRIPTION
Nieuwe MOZa Weekly van 15 juli 2026.

Daarnaast twee aanpassingen aan de weekly-tooling:
- Standaardperiode van moza-weekly-fetch verkleind naar 7 kalenderdagen
- Mattermost-pipeline gedocumenteerd als inputbron in de new-weekly skill