### PR TITLE
MOZa Weekly 22 juli 2026

### DIFF
--- a/content/weekly/2026/2026-07-22.md
+++ b/content/weekly/2026/2026-07-22.md
@@ -1,0 +1,57 @@
+---
+title: MOZa Weekly 22 juli 2026
+date: 2026-07-22
+---
+
+## Algemeen
+
+* **Stuurgroep met demo van de notificatieketen:** in de stuurgroep van 16 juli lieten we een demo zien met een fictieve applicatie bij een dienstverlener: een zaaksysteem voor vergaderstukken dat uitnodigingen verstuurt. Toen we op verzenden drukten, liep de hele keten. Vanuit het systeem van de dienstverlener ging het bericht naar het Notificatie Management Component (NMC), langs de [profieldienst](/onderwerpen/profielservice/) voor het e-mailadres, en via NotifyNL naar de mailbox van de stuurgroep. De applicatie kon daarna de bezorgstatus uitlezen.
+* **Componentenoverzicht en scenario's rondom berichten:** aan de hand van het nieuwe componentenoverzicht voor de notificatie- en profieldienst bespraken we de stand van zaken met de stuurgroep. Een van de uitkomsten: we werken samen scenario's uit rondom berichten, notificeren en profiel, inclusief wat dat betekent voor de ondernemer.
+* **Verkenning met MijnAmsterdam:** we spraken met de product owner van MijnAmsterdam en kregen een demo. MijnAmsterdam wordt vooral door inwoners gebruikt en minder door ondernemers. Veel diensten zijn wel digitaal, maar staan buiten de Mijn-omgeving. We verkennen of het centraliseren van enkele diensten winst kan opleveren. De MijnAmsterdam-omgeving is bovendien open source. Daarom bekijken we of we die kunnen toevoegen aan de [MOZa-proeftuin](/onderwerpen/proeftuin/).
+* **Team groeit:** deze maand startte een nieuwe architect om MOZa te ondersteunen. Daarnaast starten er per 1 september twee nieuwe collega's: een opgavemanager en een business analist.
+
+## Gebruikersonderzoek
+
+* **Berichtenbox getest met ondernemers:** op 13 en 14 juli deden we gebruikersonderzoek naar de Berichtenbox. We spraken zes ondernemers: een mix van zzp'ers en klein-mkb uit verschillende branches. Met een prototype liepen we scenario's door, zoals inloggen op MOZa, een bericht openen, en switchen tussen de Berichtenbox van de Belastingdienst en die van MOZa. De uitgebreide resultaten volgen later. [Bekijk het prototype](https://proef.moza.rijksapp.dev/ux-onderzoek/juli-2026/).
+* **Twee thema's uitgelicht:** in het onderzoek stonden twee thema's centraal. Het federatieve stelsel: dezelfde berichten tegelijk tonen bij de Belastingdienst en bij MOZa. En actiegerichte berichten: bijvoorbeeld direct vanuit een bericht je aangifte doen. Over de veiligheid hiervan werden zorgen geuit. Daarover gaan we met elkaar in gesprek en we zorgen dat de juiste expertise aanhaakt.
+
+## Notificatiedienst
+
+* **MVP met de Belastingdienst:** in een requirementsessie met de Belastingdienst bespraken we de input voor een eerste MVP. We toonden ook de huidige stand van het NMC.
+* **Centrale en decentrale regie:** in een overleg met VNG, Belastingdienst en Logius deelden we de uitgangspunten voor de notificatiedienst. Er lijkt overeenstemming dat de regie zowel centraal als decentraal moet plaatsvinden. Een terugkoppeling vanuit de architectuur volgt. We werken alvast aan een decentraal aansluitpunt in het NMC.
+* **Werken met NotifyNL:** we zochten uit hoe en wanneer we NotifyNL van Logius kunnen gebruiken en spraken met het team daarachter. Ook lukte het om niet-verzonden e-mails opnieuw aan te bieden. Een deel van die aanpak kunnen we hergebruiken.
+* **Uitgangspunten en documentatie:** er gebeurt veel, dus we besteden aandacht aan het bijhouden van de requirements, uitgangspunten en openstaande vragen. Zo werken we stap voor stap verder. Ook zorgen we dat de open documentatie op korte termijn weer is bijgewerkt.
+* **Beheer en bewaking:** we maakten extra monitoringdashboards die onze services in de gaten houden. Dit doen we in lijn met de Logius-voorkeuren. Zo bereiden we ons voor op de overgang naar de Logius Private Cloud.
+
+## Dienstverlenersportaal
+
+* **Concept dienstverlenersportaal:** in de stuurgroep lieten we ook een praatstuk over het dienstverlenersportaal zien. De kern: dienstverleners moeten eenvoudig kunnen aansluiten, met gemak voor developers, inzicht in wat er gebeurt via een logboek en een duidelijk proces voor governance. Je kunt er zelf doorheen klikken op [dienstverlener-moza.rijksapp.dev](https://dienstverlener-moza.rijksapp.dev/). Let op: dit is een praatstuk om snel beelden bij elkaar te brengen en input op te halen, zodat we van daaruit het goede gesprek kunnen voeren.
+* **Templatebibliotheek voor notificaties:** in NotifyNL zitten templates en we denken na over hoe je centrale en decentrale templates kunt organiseren. In het concept namen we voor nu een bibliotheek met templates op: met de standaard notificatieteksten van MijnOverheid en een eigen template voor een specifieke applicatie.
+
+## Profieldienst
+
+* **DPIA verder ingevuld:** we werkten samen met de juristen verder aan de DPIA (privacytoets) van de [profieldienst](/onderwerpen/profielservice/) en verwerkten aanvullende punten.
+* **Inhaalsprint gepland:** de afgelopen periode lag de nadruk op de notificatiedienst. Voor de profieldienst plannen we daarom een inhaalsprint in de komende periode, zodat we de nieuwste inzichten verwerken.
+
+## Berichten
+
+* **FSC-keten voor de Berichtenbox compleet:** we maakten de keten met [Federated Service Connectivity (FSC)](https://fsc-standaard.nl/hoe-werkt-fsc/) voor de Berichtenbox op het [ZAD-cluster](https://zad.rijksapp.nl/) compleet. Er draait nu een berichtenmagazijn dat via FSC wordt aangeboden, en een onderdeel dat zulke magazijnen kan aanroepen. Het uitvraagsysteem van het [Federatief Berichtenstelsel](/onderwerpen/berichten-fbs/) loopt via dat onderdeel naar de magazijnen. Een tweede magazijn volgt binnenkort.
+
+## Agenda
+
+💡 Wist je dat we (bijna) elke maandag samenwerken op het Beatrixpark in Den Haag? Wil je een keer aanhaken, dan ben je van harte welkom.
+
+**MOZa**
+
+* MOZa teamoverleg - 28 juli
+* Regieteam - 6 augustus (mogelijk september vanwege de vakantieperiode)
+* MOZa teamdag - 8 september (inclusief afsluiter met MOZa regieteam)
+* MOZa Pulse - 17 september
+* Stuurgroep - 25 september
+
+**Evenementen**
+
+* [Common Ground Fieldlab](https://commonground.nl/events/view/1a31088b-5794-466c-8bf4-79be0a678eee/common-ground-fieldlab-14-en-15-september-2026) - 14 & 15 september
+* Business Wallet B2G - 22 of 23 september
+* [Europe goes Once-Only: the Netherlands](https://www.digitaleoverheid.nl/evenementen/europe-goes-once-only-the-netherlands/) - 24 & 25 september
+* [IBDS-Stelseldag 2027](https://www.digitaleoverheid.nl/evenementen/ibds-stelseldag-2027/) - 3 februari 2027


### PR DESCRIPTION
Nieuwe MOZa Weekly voor 22 juli 2026.

Belangrijkste onderwerpen:

- **Stuurgroep 16 juli:** demo waarin de hele notificatieketen werkt (systeem dienstverlener → NMC → profieldienst → NotifyNL), inclusief het uitlezen van de bezorgstatus.
- **Componentenoverzicht:** gezamenlijke scenario's rond berichten, notificeren en profiel.
- **Gebruikersonderzoek Berichtenbox** (13 en 14 juli) met zes ondernemers; twee thema's uitgelicht (federatief stelsel en actiegerichte berichten).
- **Notificatiedienst:** MVP met de Belastingdienst, centrale en decentrale regie, werken met NotifyNL, beheer richting de Logius Private Cloud.
- **Concept dienstverlenersportaal** met templatebibliotheek voor notificaties.
- **Profieldienst:** DPIA verder ingevuld, inhaalsprint gepland.
- **Berichten:** FSC-keten voor de Berichtenbox op het ZAD-cluster compleet.

De agenda is bijgewerkt met de eerstvolgende vaste overleggen: teamoverleg 28 juli, Regieteam 6 augustus, MOZa teamdag 8 september, MOZa Pulse 17 september en Stuurgroep 25 september.
