### PR TITLE
MOZa Weekly 29 juli 2026

### DIFF
--- a/content/weekly/2026/2026-07-29.md
+++ b/content/weekly/2026/2026-07-29.md
@@ -1,0 +1,67 @@
+---
+title: MOZa Weekly 29 juli 2026
+date: 2026-07-29
+---
+
+## Algemeen
+
+* **Vakantieperiode:** het is zomer en een deel van het team is met vakantie. Sommige onderwerpen blijven daardoor even liggen. Zo ook deze wekelijkse update. Eind augustus verschijnt er weer een nieuwe.
+* **Logius vertelt over de samenwerking:** eerder meldden we al dat Logius de [intentieverklaring](/documenten/intentieverklaring/) heeft getekend. Logius publiceerde hier nu een [nieuwsbericht](https://www.logius.nl/actueel/logius-sluit-aan-bij-samenwerking-voor-mijnoverheid-zakelijk) over. Een mooie manier om de samenwerking aandacht te geven.
+* **Sprint 6 afgerond, sprint 7 gestart:** we rondden sprint 6 goed af en namen weinig werk mee naar de volgende ronde. In sprint 7 gaan we verder met onder andere een uitbreiding van het Notificatie Management Component (NMC): het toevoegen van notificatie-initiatie.
+
+## Notificatiedienst
+
+* **Pagina over de notificatiedienst online:** we publiceerden de informatie die we de afgelopen periode opbouwden op de pagina over de [notificatiedienst](/onderwerpen/notificatiedienst/). Hiermee willen we meer inzicht geven in waar we aan werken. We werken de pagina bij zodra we nieuwe inzichten hebben. Ook [de documentatie](https://docs.mijnoverheidzakelijk.nl/workspace/documentation/Notificatiedienst) over dit onderwerp heeft een update gekregen.
+* **Decentraal profiel:** je kunt het NMC nu ook gebruiken met een zogenaamd decentraal profiel. Ofwel: de dienstverlener levert zelf het e-mailadres aan waar de notificatie naartoe moet.
+* **NMC en OMC naast elkaar gelegd:** we maakten een technische vergelijking tussen het voorstel voor het NMC en het Outputmanagementcomponent (OMC), als aanvulling op de eerdere functionele vergelijking. Aanleiding waren vragen vanuit de VNG en een aantal gemeenten. De uitkomst nemen we mee in toekomstige gesprekken met deze organisaties.
+* **RVO verkent de aansluiting:** in een sessie met RVO spraken we over de notificatiedienst. Dit volgen we de komende periode op.
+* **Contactherstel verkend:** we deden een eerste analyse van de contactherstelmodule van Logius en onderzoeken hoe we die aan het NMC kunnen koppelen. We wachten nog op documentatie voordat we hier verder mee kunnen gaan.
+* **Securityreview in voorbereiding:** we stemden af met de Auditdienst Rijk (ADR) over een securityreview van de hele notificatiedienst. Na de zomer geven we dit samen verder vorm.
+
+## Dienstverlenersportaal
+
+* **Nieuwe persona's en een tweede klantreis:** we werken aan zes nieuwe [persona's](https://cx-moza.rijksapp.dev/personas/index.html) en een klantreis voor [het afnemen van de notificatiedienst](https://cx-moza.rijksapp.dev/klantreizen/afnemen-notificatiedienst/index.html). Allebei nog in concept. De persona's kregen daarbij een nieuwe look.
+* **Versnellen met AI:** voor het maken van deze persona's en klantreizen gebruiken we AI. Doordat we onze werkwijze goed vastleggen, merken we dat we nu versnellen. Die werkwijze bewaren we als skill: een vaste set instructies waarmee de AI steeds op dezelfde manier werkt. Deze skill stellen we straks ook beschikbaar.
+* **Federatief aansluiten uitgeplozen:** voor de klantreis verdiepten we ons in het aansluitproces. We keken naar het proces van Digipoort. De volgende stap is dit verwerken in de klantreis en in het concept van het dienstverlenersportaal.
+* **Vergelijking met EVA:** Logius heeft de afgelopen periode gewerkt aan Eenvoudig Aansluiten (EVA). Vanuit MOZa denken we ook na over wat nodig is om dienstverleners aan te sluiten. Om kennis uit te wisselen en van elkaar te leren gaven we demo's van EVA en van het [concept dienstverlenersportaal](https://dienstverlener-moza.rijksapp.dev/).
+* **Inloggen kan op vele manieren:** in het verlengde van de kennisuitwisseling met EVA zagen we een verschil. Zij gaan uit van inloggen met eHerkenning, wij kijken naar Single Sign-On (Rijks)overheid. Zakelijke gebruikers loggen op verschillende manieren in. Daar houden we in het concept van het dienstverlenersportaal ook rekening mee. We volgen daarbij de ontwikkelingen rond [GovConext](https://govroam.nl/diensten-govconext/govconext/), dat een oplossing biedt waarbij meerdere organisaties zich kunnen aansluiten.
+
+## Profieldienst
+
+* **Profieldienst nu via FSC:** we bouwden de keten met [Federated Service Connectivity (FSC)](https://fsc-standaard.nl/hoe-werkt-fsc/) op het [ZAD-cluster](https://zad.rijksapp.nl/) verder uit. We bevragen de profieldienst nu ook via FSC.
+
+## Berichten
+
+* **Demo-engine voor de Berichtenbox:** we begonnen aan een demo-engine waarmee we scenario's voor de Berichtenbox kunnen laten zien. Denk aan berichten ophalen, verplaatsen naar een map of verwijderen. Maar ook aan minder prettige situaties: een berichtenmagazijn dat traag is of niet reageert, of een nieuw bericht dat binnenkomt tijdens je sessie.
+
+## RegelRecht en digitale assistent
+
+* **Validatie met de editor:** we bereidden onze volgende afspraak met RVO over het [Financieel CV](https://www.rvo.nl/praktijkverhalen/regelhulp-financieel-cv-een-gids-voor-inclusief-werkgeverschap) voor en zetten weer een stap in de validatie met de RegelRecht editor. Ook begonnen we met het verwerken van de input uit de vorige afspraak.
+* **AI-Act-classificatie:** samen met het AI Gilde van het Rijks ICT Gilde maakten we een plan om de classificatie onder de AI-verordening rond te krijgen. Midden augustus maken we dit af.
+* **Meer profielen in de proefopstelling:** voor de proefopstelling van de [digitale assistent](/onderwerpen/digitale-assistent/) zetten we bedrijfsdata om naar meerdere profielen.
+
+## Logboek dataverwerkingen
+
+* **Package bijgewerkt:** we brachten ons [Logboek Dataverwerkingen-package](https://github.com/MinBZK/moza-logboekdataverwerking) op v1 van de LDV-standaard. Ook voegden we ondersteuning voor PostgreSQL toe en werkten we onderdelen bij om bekende kwetsbaarheden op te lossen.
+
+## Wie mag wat
+
+* **Federatieve concepten:** we verdiepten ons in de federatieve concepten achter de vraag "wie mag wat". De oplossing is er nog niet, maar de puzzelstukjes worden langzaam duidelijker.
+
+## Agenda
+
+💡 Wist je dat we (bijna) elke maandag samenwerken op het Beatrixpark in Den Haag? Wil je een keer aanhaken, dan ben je van harte welkom.
+
+**MOZa**
+
+* Regieteam - 3 september
+* MOZa teamdag - 8 september (inclusief afsluiter met MOZa regieteam)
+* MOZa Pulse - 17 september
+* Stuurgroep - 25 september
+
+**Evenementen**
+
+* [Common Ground Fieldlab](https://commonground.nl/events/view/1a31088b-5794-466c-8bf4-79be0a678eee/common-ground-fieldlab-14-en-15-september-2026) - 14 & 15 september
+* [Symposium De European Business Wallet](https://ecp.nl/agenda/symposiumde-european-business-wallet-op-naar-eenvoudigere-overheidsdienstverlening-aan-bedrijven/) - 22 september
+* [Europe goes Once-Only: the Netherlands](https://www.digitaleoverheid.nl/evenementen/europe-goes-once-only-the-netherlands/) - 24 & 25 september
+* [IBDS-Stelseldag 2027](https://www.digitaleoverheid.nl/evenementen/ibds-stelseldag-2027/) - 3 februari 2027


### PR DESCRIPTION
Nieuwe MOZa Weekly voor 29 juli 2026.

## Inhoud

Secties deze week: Algemeen, Notificatiedienst, Dienstverlenersportaal, Profieldienst, Berichten, RegelRecht en digitale assistent, Logboek dataverwerkingen en Wie mag wat.

Belangrijkste onderwerpen:

- De pagina over de notificatiedienst staat online, plus een decentraal profiel in het NMC
- Logius publiceerde een nieuwsbericht over de ondertekende intentieverklaring
- Kennisuitwisseling met Eenvoudig Aansluiten (EVA) en de vraag hoe dienstverleners inloggen
- Nieuwe persona's en een tweede klantreis voor het dienstverlenersportaal

Dit is de laatste editie voor de vakantieperiode; eind augustus verschijnt de volgende.

## Agenda

Regieteam verplaatst naar 3 september. Het symposium over de European Business Wallet (22 september) is toegevoegd met datum en link.

## Controles

`just check` is groen: Hugo-build slaagt en htmltest vindt geen broken links over 83 documenten.